### PR TITLE
Adding epsagon.Config struct to hold all data passed to epsagon

### DIFF
--- a/example/simple_lambda/main.go
+++ b/example/simple_lambda/main.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/epsagon/epsagon-go/epsagon"
 	"log"
-	"os"
 )
 
 func myHandler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
@@ -15,8 +14,8 @@ func myHandler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRes
 
 func main() {
 	log.Println("enter main")
-	lambda.Start(epsagon.WrapLambdaHandler(
-		"erez-test-go", os.Getenv("EPSAGON_TOKEN"),
-		"http://dev.tc.epsagon.com", false, myHandler,
-	))
+	config := epsagon.Config{
+		ApplicationName: "erez-test-go",
+		CollectorURL:    "http://dev.tc.epsagon.com"}
+	lambda.Start(epsagon.WrapLambdaHandler(&config, myHandler))
 }

--- a/example/simple_lambda/serverless.yml
+++ b/example/simple_lambda/serverless.yml
@@ -4,6 +4,8 @@ provider:
   name: aws
   runtime: go1.x
   region: eu-west-1
+  environment:
+    EPSAGON_TOKEN: ${env:EPSAGON_TOKEN}
 
 package:
   exclude:


### PR DESCRIPTION
Adding a configuration struct to allow sending default values and finding them from the environment.

This also has the `Debug` option that should be used to print debugging messages.