### PR TITLE
adding aws-sdk-go wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ test
 # vendor directory are not needed here
 vendor
 example/simple_lambda/bin/hello
+example/sqs_trigger/hello/main
+example/sqs_trigger/triggered/main

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dep ensure -add github.com/epsagon/com
 ## Usage
 
 ### To wrap a lambda handler
-```
+```go
 package main
 
 import (
@@ -31,17 +31,29 @@ func myHandler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRes
 func main() {
 	log.Println("enter main")
 	lambda.Start(epsagon.WrapLambdaHandler(
-		"APPLICATION-NAME", os.Environ("EPSAGON_TOKEN"),
-		"http://tc.epsagon.com", false, myHandler,
-	))
+        &epsagon.Config{ApplicationName: "APPLICATION-NAME"},
+        myHandler))
 }
 ```
 
 `epsagon.WrapLambdaHandler` will wrap your handler with code that will start a tracer that will wait for events and will send them to the collector when the lambda finishes
 
 ### Wrapping other libraries
-TODO
+#### aws-sdk-go
+Wrapping of aws-sdk-go is done through the Session object that has to be created to communicate with AWS:
+```go
+import (
+...
+	"github.com/epsagon/epsagon-go/wrappers/aws/aws-sdk-go/aws"
+)
+    ...
+	sess := epsagonawswrapper.WrapSession(session.Must(session.NewSession()))
+	svcSQS := sqs.New(sess)
+```
 
 ## Configuration
-
-
+The epsagon.Config structure that is sent to `WraphLambdaHandler` has some fields to customize epsagons behaviour:
+- `MetadataOnly`: Boolean flag to make sure to only send metadata information and not the data itself
+- `Debug`: Will print debug information form epsagon
+- `CollectorURL`: Set the collector's address instead of getting it from `EPSAGON_COLLECTOR_URL` or using epsagon's default in the same aws region
+- `Token`: Your epsagon token (The default is to attempt to read this from `EPSAGON_TOKEN` environment variable)

--- a/epsagon/common_utils.go
+++ b/epsagon/common_utils.go
@@ -2,6 +2,7 @@ package epsagon
 
 import "time"
 
+// GetTimestamp returns the current time in miliseconds
 func GetTimestamp() float64 {
 	return float64(time.Now().UnixNano()) / float64(time.Millisecond) / float64(time.Nanosecond) / 1000.0
 }

--- a/example/simple_lambda/main.go
+++ b/example/simple_lambda/main.go
@@ -18,6 +18,6 @@ func main() {
 	log.Println("enter main")
 	config := epsagon.Config{
 		ApplicationName: "epsagon-test-go",
-		CollectorURL:    "http://dev.tc.epsagon.com"}
+	}
 	lambda.Start(epsagon.WrapLambdaHandler(&config, myHandler))
 }

--- a/example/simple_lambda/main.go
+++ b/example/simple_lambda/main.go
@@ -7,11 +7,12 @@ import (
 	"log"
 )
 
+// Response is an API gateway response type
 type Response events.APIGatewayProxyResponse
 
 func myHandler(request events.APIGatewayProxyRequest) (Response, error) {
 	log.Println("In myHandler, received body: ", request.Body)
-	return Response {Body: "yes", StatusCode: 200}, nil
+	return Response{Body: "yes", StatusCode: 200}, nil
 }
 
 func main() {

--- a/example/simple_lambda/serverless.yml
+++ b/example/simple_lambda/serverless.yml
@@ -6,6 +6,7 @@ provider:
   region: eu-west-1
   environment:
     EPSAGON_TOKEN: ${env:EPSAGON_TOKEN}
+    EPSAGON_COLLECTOR_URL: ${env:EPSAGON_COLLECTOR_URL}
 
 functions:
   hello:

--- a/example/sqs_trigger/hello/main.go
+++ b/example/sqs_trigger/hello/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+
+	"github.com/epsagon/epsagon-go/epsagon"
+	"github.com/epsagon/epsagon-go/wrappers/aws/aws-sdk-go/aws"
+)
+
+func myHandler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	log.Println("In myHandler, received body: ", request.Body)
+
+	// sess := session.Must(session.NewSession())
+	// epsagon wrapper for aws-sdk-go
+	sess := epsagonawswrapper.WrapSession(session.Must(session.NewSession()))
+
+	svcSQS := sqs.New(sess)
+
+	sqsQueueName := os.Getenv("SQS_NAME")
+	queueURL, err := svcSQS.GetQueueUrl(&sqs.GetQueueUrlInput{QueueName: &sqsQueueName})
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to get SQS Queue Url: %v", err)
+		log.Println(errMsg)
+		return events.APIGatewayProxyResponse{Body: errMsg, StatusCode: 500}, err
+	}
+	_, err = svcSQS.SendMessage(&sqs.SendMessageInput{
+		MessageBody: &request.Body,
+		QueueUrl:    queueURL.QueueUrl,
+	})
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to send SQS message: %v", err)
+		log.Println(errMsg)
+		return events.APIGatewayProxyResponse{Body: errMsg, StatusCode: 500}, err
+	}
+	return events.APIGatewayProxyResponse{Body: request.Body, StatusCode: 200}, nil
+}
+
+func main() {
+	log.Println("enter main")
+	config := epsagon.Config{
+		ApplicationName: "sqs-test-go",
+		Debug:           true,
+	}
+	lambda.Start(epsagon.WrapLambdaHandler(&config, myHandler))
+}

--- a/example/sqs_trigger/makefile
+++ b/example/sqs_trigger/makefile
@@ -1,0 +1,14 @@
+
+
+deploy: build
+	sls deploy
+
+build: triggered hello
+
+triggered: triggered/main.go
+	go build -o triggered/main triggered/main.go
+
+hello: hello/main.go
+	go build -o hello/main hello/main.go
+
+.PHONY: all build triggered hello

--- a/example/sqs_trigger/serverless.yml
+++ b/example/sqs_trigger/serverless.yml
@@ -1,0 +1,62 @@
+service: example-go-app-sqs
+
+custom:
+  QueueName: GoExampleTestQueue
+
+provider:
+  name: aws
+  runtime: go1.x
+  region: eu-west-1
+  environment:
+    EPSAGON_TOKEN: ${env:EPSAGON_TOKEN}
+    EPSAGON_COLLECTOR_URL: ${env:EPSAGON_COLLECTOR_URL}
+
+  queueArn:
+    Fn::Join:
+      - ":"
+      - - "arn:aws:sqs"
+        - ${self:provider.region}
+        - Ref: AWS::AccountId
+        - ${self:custom.QueueName}
+
+  iamRoleStatements:
+    - Effect: "Allow"
+      Action:
+        - "sqs:ListQueues"
+      Resource:
+        Fn::Join:
+          - ":"
+          - - "arn:aws:sqs"
+            - ${self:provider.region}
+            - Ref: AWS::AccountId
+            - "*"
+    - Effect: "Allow"
+      Action:
+        - "sqs:*"
+      Resource: ${self:provider.queueArn}
+
+functions:
+  hello:
+    handler: hello/main
+    events:
+      - http:
+          path: hello
+          method: post
+    environment:
+      SQS_NAME: ${self:custom.QueueName}
+  triggered:
+    handler: triggered/main
+    events:
+      - sqs:
+          arn:
+            Fn::GetAtt:
+              - ExampleTestQueue
+              - Arn
+          batchSize: 1
+
+resources:
+  Resources:
+    ExampleTestQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:custom.QueueName}

--- a/example/sqs_trigger/triggered/main.go
+++ b/example/sqs_trigger/triggered/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/epsagon/epsagon-go/epsagon"
+	"log"
+)
+
+func mySQSHandler(sqsEvents events.SQSEvent) error {
+	log.Println("In mySQSHandler, received body: ", sqsEvents)
+	return nil
+}
+
+func main() {
+	log.Println("enter main")
+	config := epsagon.Config{
+		ApplicationName: "sqs-test-go",
+	}
+	lambda.Start(epsagon.WrapLambdaHandler(&config, mySQSHandler))
+}

--- a/wrappers/aws/aws-sdk-go/aws/aws.go
+++ b/wrappers/aws/aws-sdk-go/aws/aws.go
@@ -1,0 +1,125 @@
+package epsagonawswrapper
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/epsagon/epsagon-go/epsagon"
+	"github.com/epsagon/epsagon-go/protocol"
+	"log"
+	"strings"
+	"time"
+)
+
+// WrapSession wraps an aws session.Session with epsgaon traces
+func WrapSession(s *session.Session) *session.Session {
+	s.Handlers.Complete.PushFrontNamed(
+		request.NamedHandler{
+			Name: "github.com/epsagon/epsagon-go/wrappers/aws/aws-sdk-go/aws/aws.go",
+			Fn:   completeEventData,
+		})
+	return s
+}
+
+func getTimeStampFromRequest(r *request.Request) float64 {
+	return float64(r.Time.UTC().UnixNano()) / float64(time.Millisecond) / float64(time.Nanosecond) / 1000.0
+}
+
+func completeEventData(r *request.Request) {
+	if epsagon.GetGlobalTracerConfig().Debug {
+		log.Printf("EPSAGON DEBUG OnComplete request response: %+v\n", r.HTTPResponse)
+		log.Printf("EPSAGON DEBUG OnComplete request Operation: %+v\n", r.Operation)
+		log.Printf("EPSAGON DEBUG OnComplete request ClientInfo: %+v\n", r.ClientInfo)
+		log.Printf("EPSAGON DEBUG OnComplete request Params: %+v\n", r.Params)
+		log.Printf("EPSAGON DEBUG OnComplete request Data: %+v\n", r.Data)
+	}
+	endTime := epsagon.GetTimestamp()
+	event := protocol.Event{
+		Id:        r.RequestID,
+		StartTime: getTimeStampFromRequest(r),
+		Origin:    "aws-sdk",
+		Resource:  extractResourceInformation(r),
+	}
+	event.Duration = endTime - event.StartTime
+	epsagon.AddEvent(&event)
+}
+
+type extractor func(*request.Request, *protocol.Resource)
+
+var awsResourceDataExtractors = map[string]map[string]extractor{
+	"sqs": map[string]extractor{
+		"SendMessage": sqsSendMessageExtractor,
+		"GetQueueUrl": sqsGetQueueURLExtractor,
+	},
+}
+
+func extractResourceInformation(r *request.Request) *protocol.Resource {
+	res := protocol.Resource{
+		Type:      r.ClientInfo.ServiceName,
+		Operation: r.Operation.Name,
+		Metadata:  make(map[string]string),
+	}
+	extractor := awsResourceDataExtractors[res.Type][res.Operation]
+	if extractor != nil {
+		extractor(r, &res)
+	} else {
+		defaultExtractor(r, &res)
+	}
+	return &res
+}
+
+func defaultExtractor(r *request.Request, res *protocol.Resource) {
+	if epsagon.GetGlobalTracerConfig().Debug {
+		log.Println("EPSAGON DEBUG:: entering defaultExtractor")
+	}
+	extractInterfaceToMetadata(r.Data, res)
+	extractInterfaceToMetadata(r.Params, res)
+}
+
+func extractInterfaceToMetadata(input interface{}, res *protocol.Resource) {
+	var data map[string]interface{}
+	rawJSON, err := json.Marshal(input)
+	if err != nil {
+		log.Printf("EPSAGON DEBUG: Failed to marshal input: %+v\n", input)
+		return
+	}
+	err = json.Unmarshal(rawJSON, &data)
+	if err != nil {
+		log.Printf("EPSAGON DEBUG: Failed to unmarshal input: %+v\n", rawJSON)
+		return
+	}
+	for key, value := range data {
+		res.Metadata[key] = fmt.Sprintf("%v", value)
+	}
+}
+
+func sqsSendMessageExtractor(r *request.Request, res *protocol.Resource) {
+	input, ok := r.Params.(*sqs.SendMessageInput)
+	if !ok {
+		log.Printf("EPSAGON DEBUG: sqsSendMessageExtractor failed to unmarshal data: r.Params %+v", r.Params)
+		defaultExtractor(r, res)
+		return
+	}
+	urlParts := strings.Split(*input.QueueUrl, "/")
+	res.Name = urlParts[len(urlParts)-1]
+	output, ok := r.Data.(*sqs.SendMessageOutput)
+	if !ok {
+		log.Printf("EPSAGON DEBUG: sqsSendMessageExtractor failed to unmarshal data: r.Data %+v", r.Data)
+		defaultExtractor(r, res)
+		return
+	}
+	res.Metadata["Message ID"] = *output.MessageId
+	res.Metadata["MD5 Of Message Body"] = *output.MD5OfMessageBody
+}
+
+func sqsGetQueueURLExtractor(r *request.Request, res *protocol.Resource) {
+	input, ok := r.Params.(*sqs.GetQueueUrlInput)
+	if !ok {
+		log.Printf("EPSAGON DEBUG: sqsGetQueueURLExtractor failed to unmarshal data: r.Params %+v", r.Params)
+		defaultExtractor(r, res)
+		return
+	}
+	res.Name = *input.QueueName
+}


### PR DESCRIPTION
This adds a generic wrapper to aws-sdk-go through wrapping the session.
It only knows to extract the data from two SQS events so far, but more will be added in the future.

```go
import (
...
	"github.com/epsagon/epsagon-go/wrappers/aws/aws-sdk-go/aws"
)
...

sess := epsagonawswrapper.WrapSession(session.Must(session.NewSession()))
```

See the example SQS application for more information