### PR TITLE
Adding error recovery to lambda wrapper

### DIFF
--- a/epsagon/common_utils.go
+++ b/epsagon/common_utils.go
@@ -12,6 +12,9 @@ func GetTimestamp() float64 {
 	return float64(time.Now().UnixNano()) / float64(time.Millisecond) / float64(time.Nanosecond) / 1000.0
 }
 
+// AddExceptionTypeAndMessage adds an exception to the current tracer with
+// the current stack and time.
+// exceptionType, msg are strings that will be added to the exception
 func AddExceptionTypeAndMessage(exceptionType, msg string) {
 	stack := debug.Stack()
 	AddException(&protocol.Exception{
@@ -23,46 +26,9 @@ func AddExceptionTypeAndMessage(exceptionType, msg string) {
 }
 
 // GeneralEpsagonRecover recover function that will send exception to epsagon
+// exceptionType, msg are strings that will be added to the exception
 func GeneralEpsagonRecover(exceptionType, msg string) {
 	if r := recover(); r != nil {
 		AddExceptionTypeAndMessage(exceptionType, fmt.Sprintf("%s:%+v", msg, r))
 	}
-}
-
-// MockedEpsagonTracer will not send traces if closed
-type MockedEpsagonTracer struct {
-	Exceptions *[]*protocol.Exception
-	Events     *[]*protocol.Event
-	Config     *Config
-}
-
-// Run implementes mocked Run
-func (t *MockedEpsagonTracer) Run() {}
-
-// Running implementes mocked Running
-func (t *MockedEpsagonTracer) Running() bool {
-	return false
-}
-
-// Stop implementes mocked Stop
-func (t *MockedEpsagonTracer) Stop() {}
-
-// Stopped implementes mocked Stopped
-func (t *MockedEpsagonTracer) Stopped() bool {
-	return false
-}
-
-// AddEvent implementes mocked AddEvent
-func (t *MockedEpsagonTracer) AddEvent(e *protocol.Event) {
-	*t.Events = append(*t.Events, e)
-}
-
-// AddException implementes mocked AddEvent
-func (t *MockedEpsagonTracer) AddException(e *protocol.Exception) {
-	*t.Exceptions = append(*t.Exceptions, e)
-}
-
-// GetConfig implementes mocked AddEvent
-func (t *MockedEpsagonTracer) GetConfig() *Config {
-	return t.Config
 }

--- a/epsagon/generic_handler_test.go
+++ b/epsagon/generic_handler_test.go
@@ -8,13 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"reflect"
-	"testing"
 )
-
-func TestGenericHandler(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "GenericHandler suite")
-}
 
 var _ = Describe("GenericHandler suite", func() {
 	Describe("validateArguments", func() {

--- a/epsagon/lambda_trigger_test.go
+++ b/epsagon/lambda_trigger_test.go
@@ -7,14 +7,8 @@ import (
 	"github.com/epsagon/epsagon-go/protocol"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 	"time"
 )
-
-func TestEpsagonLambdaTrigger(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "epsagon trigger suite")
-}
 
 type inventedEvent struct {
 	Name        string

--- a/epsagon/lambda_wrapper_test.go
+++ b/epsagon/lambda_wrapper_test.go
@@ -1,0 +1,139 @@
+package epsagon
+
+import (
+	// "fmt"
+	"context"
+	"encoding/json"
+	"github.com/epsagon/epsagon-go/protocol"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"reflect"
+)
+
+var _ = Describe("lambda_wrapper", func() {
+	Describe("WrapLambdaHandler", func() {
+		Context("called with nil config", func() {
+			It("Returns a function suitable for lambda", func() {
+				wrapper := WrapLambdaHandler(nil, func() {})
+				wrapperType := reflect.TypeOf(wrapper)
+				Expect(wrapperType.Kind()).To(Equal(reflect.Func))
+				_, err := validateArguments(wrapperType)
+				Expect(err).To(BeNil())
+				err = validateReturns(wrapperType)
+				Expect(err).To(BeNil())
+			})
+			It("calls the wrapped function", func() {
+				GlobalTracer = nil
+				called := false
+				wrapper := WrapLambdaHandler(nil, func() {
+					called = true
+				})
+				wrapperValue := reflect.ValueOf(wrapper)
+				ctx := context.Background()
+				var args []reflect.Value
+				args = append(args, reflect.ValueOf(ctx))
+				args = append(args, reflect.ValueOf(json.RawMessage("{}")))
+				wrapperValue.Call(args)
+				Expect(called).To(Equal(true))
+			})
+		})
+		Context("called with nil handler", func() {
+			It("Returns a function suitable for lambda", func() {
+				wrapper := WrapLambdaHandler(&Config{}, nil)
+				wrapperType := reflect.TypeOf(wrapper)
+				_, err := validateArguments(wrapperType)
+				Expect(err).To(BeNil())
+				err = validateReturns(wrapperType)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+	Describe("Invoke", func() {
+		Context("Happy Flows", func() {
+			var (
+				events     []*protocol.Event
+				exceptions []*protocol.Exception
+			)
+			BeforeEach(func() {
+				events = make([]*protocol.Event, 0)
+				exceptions = make([]*protocol.Exception, 0)
+				GlobalTracer = &MockedEpsagonTracer{
+					Events:     &events,
+					Exceptions: &exceptions,
+				}
+			})
+			It("Adds an Event, Trigger and calls handler", func() {
+				called := false
+				wrapper := &epsagonLambdaWrapper{
+					config:  &Config{},
+					handler: makeGenericHandler(func() { called = true }),
+				}
+
+				ctx := context.Background()
+				payload := json.RawMessage("{}")
+				wrapper.Invoke(ctx, payload)
+
+				Expect(called).To(Equal(true))
+				Expect(exceptions).To(BeEmpty())
+				Expect(events).To(HaveLen(2))
+			})
+		})
+		Describe("Error Flows", func() {
+			var (
+				events     []*protocol.Event
+				exceptions []*protocol.Exception
+				called     bool
+				wrapper    *epsagonLambdaWrapper
+			)
+			BeforeEach(func() {
+				called = false
+				events = make([]*protocol.Event, 0)
+				exceptions = make([]*protocol.Exception, 0)
+				wrapper = &epsagonLambdaWrapper{
+					config:  &Config{},
+					handler: makeGenericHandler(func() { called = true }),
+				}
+			})
+			Context("Failed to add event", func() {
+				It("Recovers and adds exception", func() {
+					GlobalTracer = &MockedEpsagonTracer{
+						Events:        &events,
+						Exceptions:    &exceptions,
+						panicAddEvent: true,
+					}
+					wrapper.Invoke(context.Background(), json.RawMessage("{}"))
+					Expect(called).To(Equal(true))
+					Expect(exceptions).To(HaveLen(2))
+					Expect(events).To(BeEmpty())
+				})
+			})
+			Context("Failed to add exception and event", func() {
+				It("Recovers and does nothing becuase it can't", func() {
+					GlobalTracer = &MockedEpsagonTracer{
+						Events:            &events,
+						Exceptions:        &exceptions,
+						panicAddEvent:     true,
+						panicAddException: true,
+					}
+					wrapper.Invoke(context.Background(), json.RawMessage("{}"))
+					Expect(called).To(Equal(true))
+					Expect(exceptions).To(BeEmpty())
+					Expect(events).To(BeEmpty())
+				})
+			})
+			Context("Failed to stop tracer", func() {
+				It("Recovers and does nothing because it can't", func() {
+					GlobalTracer = &MockedEpsagonTracer{
+						Events:     &events,
+						Exceptions: &exceptions,
+						panicStop:  true,
+					}
+					wrapper.Invoke(context.Background(), json.RawMessage("{}"))
+					Expect(called).To(Equal(true))
+					Expect(exceptions).To(BeEmpty())
+					Expect(events).To(HaveLen(2))
+				})
+			})
+		})
+	})
+})

--- a/epsagon/mocked_tracer.go
+++ b/epsagon/mocked_tracer.go
@@ -1,0 +1,62 @@
+package epsagon
+
+import (
+	"github.com/epsagon/epsagon-go/protocol"
+)
+
+// MockedEpsagonTracer will not send traces if closed
+type MockedEpsagonTracer struct {
+	Exceptions *[]*protocol.Exception
+	Events     *[]*protocol.Event
+	Config     *Config
+
+	panicStart        bool
+	panicAddEvent     bool
+	panicAddException bool
+	panicStop         bool
+}
+
+// Start implementes mocked Start
+func (t *MockedEpsagonTracer) Start() {
+	if t.panicStart {
+		panic("panic in Start()")
+	}
+}
+
+// Running implementes mocked Running
+func (t *MockedEpsagonTracer) Running() bool {
+	return false
+}
+
+// Stop implementes mocked Stop
+func (t *MockedEpsagonTracer) Stop() {
+	if t.panicStop {
+		panic("panic in Stop()")
+	}
+}
+
+// Stopped implementes mocked Stopped
+func (t *MockedEpsagonTracer) Stopped() bool {
+	return false
+}
+
+// AddEvent implementes mocked AddEvent
+func (t *MockedEpsagonTracer) AddEvent(e *protocol.Event) {
+	if t.panicAddEvent {
+		panic("panic in AddEvent()")
+	}
+	*t.Events = append(*t.Events, e)
+}
+
+// AddException implementes mocked AddEvent
+func (t *MockedEpsagonTracer) AddException(e *protocol.Exception) {
+	if t.panicAddException {
+		panic("panic in AddException()")
+	}
+	*t.Exceptions = append(*t.Exceptions, e)
+}
+
+// GetConfig implementes mocked AddEvent
+func (t *MockedEpsagonTracer) GetConfig() *Config {
+	return t.Config
+}

--- a/epsagon/tracer_test.go
+++ b/epsagon/tracer_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestEpsagonTracer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "epsagonTracer suite")
+	RunSpecs(t, "Epsagon Core Suite")
 }
 
 var _ = Describe("epsagonTracer suite", func() {


### PR DESCRIPTION
I tried to split the operations in `Invoke` to before/after the invocation of the handler. Each part can recover if possible (so a bug in a trigger will not prevent the function event from being created).
If something happens when starting/stopping the tracer then the recovery calls the handler if it hasn't been called yet and returns silently.