### PR TITLE
Handle send traces error response

### DIFF
--- a/epsagon/tracer_test.go
+++ b/epsagon/tracer_test.go
@@ -3,6 +3,7 @@ package epsagon
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -62,29 +63,49 @@ func testWithTracer(timeout *time.Duration, operations func()) *protocol.Trace {
 	}
 }
 
+type stubHTTPClient struct {
+	httpClient *http.Client
+	PostError  error
+}
+
+func (s stubHTTPClient) Post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
+	if s.PostError != nil {
+		return nil, s.PostError
+	}
+	return s.httpClient.Post(url, contentType, body)
+}
 
 func Test_handleSendTracesResponse(t *testing.T) {
 	tests := []struct {
 		name          string
 		apiResponse   string
 		apiStatusCode int
-		customURL     string
+		httpClient    stubHTTPClient
 		expectedLog   string
 	}{
 		{
 			name:          "No Log",
 			apiResponse:   `{"test":"valid"}`,
 			apiStatusCode: http.StatusOK,
-			expectedLog:   "",
+			httpClient: stubHTTPClient{
+				httpClient: &http.Client{Timeout: time.Duration(time.Second)},
+			},
+			expectedLog: "",
 		},
 		{
-			name:        "Error With No Response",
-			customURL:   "http://not-valid-blackole.local.test",
+			name: "Error With No Response",
+			httpClient: stubHTTPClient{
+				httpClient: &http.Client{Timeout: time.Duration(time.Second)},
+				PostError:  fmt.Errorf("Post http://not-valid-blackole.local.test: dial tcp: lookup not-valid-blackole.local.test: no such host"),
+			},
 			expectedLog: fmt.Sprintf("Error while sending traces \nPost http://not-valid-blackole.local.test: dial tcp: lookup not-valid-blackole.local.test: no such host"),
 		},
 		{
-			name:          "Error With 5XX Response",
-			apiResponse:   `{"error":"failed to send traces"}`,
+			name:        "Error With 5XX Response",
+			apiResponse: `{"error":"failed to send traces"}`,
+			httpClient: stubHTTPClient{
+				httpClient: &http.Client{Timeout: time.Duration(time.Second)},
+			},
 			apiStatusCode: http.StatusInternalServerError,
 			expectedLog:   fmt.Sprintf("Error while sending traces \n{\"error\":\"failed to send traces\"}"),
 		},
@@ -102,12 +123,7 @@ func Test_handleSendTracesResponse(t *testing.T) {
 				w.Write([]byte(test.apiResponse))
 			}))
 			defer server.Close()
-			url := server.URL
-			if test.customURL != "" {
-				url = test.customURL
-			}
-			client := &http.Client{Timeout: time.Duration(time.Second)}
-			resp, err := client.Post(url, "application/json", nil)
+			resp, err := test.httpClient.Post(server.URL, "application/json", nil)
 			handleSendTracesResponse(resp, err)
 
 			if !strings.Contains(buf.String(), test.expectedLog) {
@@ -117,4 +133,3 @@ func Test_handleSendTracesResponse(t *testing.T) {
 		})
 	}
 }
-

--- a/epsagon/tracer_test.go
+++ b/epsagon/tracer_test.go
@@ -1,6 +1,14 @@
 package epsagon
 
 import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+
 	// "fmt"
 	"github.com/epsagon/epsagon-go/internal"
 	"github.com/epsagon/epsagon-go/protocol"
@@ -53,3 +61,60 @@ func testWithTracer(timeout *time.Duration, operations func()) *protocol.Trace {
 		return trace
 	}
 }
+
+
+func Test_handleSendTracesResponse(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiResponse   string
+		apiStatusCode int
+		customURL     string
+		expectedLog   string
+	}{
+		{
+			name:          "No Log",
+			apiResponse:   `{"test":"valid"}`,
+			apiStatusCode: http.StatusOK,
+			expectedLog:   "",
+		},
+		{
+			name:        "Error With No Response",
+			customURL:   "http://not-valid-blackole.local.test",
+			expectedLog: fmt.Sprintf("Error while sending traces \nPost http://not-valid-blackole.local.test: dial tcp: lookup not-valid-blackole.local.test: no such host"),
+		},
+		{
+			name:          "Error With 5XX Response",
+			apiResponse:   `{"error":"failed to send traces"}`,
+			apiStatusCode: http.StatusInternalServerError,
+			expectedLog:   fmt.Sprintf("Error while sending traces \n{\"error\":\"failed to send traces\"}"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			//Read the logs to a buffer
+			buf := bytes.Buffer{}
+			log.SetOutput(&buf)
+			defer func() {
+				log.SetOutput(os.Stderr)
+			}()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(test.apiStatusCode)
+				w.Write([]byte(test.apiResponse))
+			}))
+			defer server.Close()
+			url := server.URL
+			if test.customURL != "" {
+				url = test.customURL
+			}
+			client := &http.Client{Timeout: time.Duration(time.Second)}
+			resp, err := client.Post(url, "application/json", nil)
+			handleSendTracesResponse(resp, err)
+
+			if !strings.Contains(buf.String(), test.expectedLog) {
+				t.Errorf("Unexpected log: expected %s got %s", test.expectedLog, buf.String())
+			}
+
+		})
+	}
+}
+


### PR DESCRIPTION

This is to fix a panic that can happen when an error is returned from the sendTraces HTTP call.

## Steps to reproduce:
If you set in your env `AWS_DEFAULT_REGION` or `AWS_REGION` to something not AWS valid and you also not set the `EPSAGON_COLLECTOR_URL` then this line will create a url that will make the trace request fail https://github.com/epsagon/epsagon-go/blob/master/epsagon/tracer.go#L151.  So it will panic as `resp` will be `nil` and we will try to access it.

## What was done:
* If an error is gets returned from the http call; log only that 
* If a 5XX response is returned then log the response body

Following the http.Do docs for guidance https://github.com/golang/go/blob/master/src/net/http/client.go#L508