### PR TITLE
Add constructor for the tracer Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ func myHandler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRes
 func main() {
 	log.Println("enter main")
 	lambda.Start(epsagon.WrapLambdaHandler(
-        &epsagon.Config{ApplicationName: "APPLICATION-NAME"},
+        epsagon.NewTracerConfig("APPLICATION-NAME","EPSAGON-TOKEN"),
         myHandler))
 }
 ```

--- a/epsagon/tracer.go
+++ b/epsagon/tracer.go
@@ -32,6 +32,16 @@ type Tracer interface {
 	GetConfig() *Config
 }
 
+// NewTracerConfig creates a new tracer Config
+func NewTracerConfig(applicationName, token string) *Config {
+	return &Config{
+		ApplicationName: applicationName,
+		Token:           token,
+		MetadataOnly:    true,
+		Debug:           false,
+	}
+}
+
 // Config is the configuration for Epsagon's tracer
 type Config struct {
 	ApplicationName string


### PR DESCRIPTION
# What was done:
* Add a constructor for the tracer Config that is safe to be used in production.

# Reasoning
Reasoning behind this change is to set by default the `MetadataOnly` flag to true, so it will be avoided leaking any kind of sensitive data by accidents and make the change of this flag explicit.

@enoodle any thoughts on this?