### PR TITLE
handle lambdas that return error

### DIFF
--- a/epsagon/lambda_wrapper.go
+++ b/epsagon/lambda_wrapper.go
@@ -188,6 +188,12 @@ func (handler *epsagonLambdaWrapper) InvokeClientLambda(
 	handler.invoking = false
 	if err != nil {
 		invokeInfo.errorStatus = protocol.ErrorCode_ERROR
+		invokeInfo.ExceptionInfo = &protocol.Exception{
+			Type:      "Error Result",
+			Message:   err.Error(),
+			Traceback: "",
+			Time:      GetTimestamp(),
+		}
 	}
 	invokeInfo.result = result
 	invokeInfo.err = err

--- a/example/exp_example/main.go
+++ b/example/exp_example/main.go
@@ -16,10 +16,7 @@ func expHandler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRe
 
 func main() {
 	log.Println("enter main")
-	config := epsagon.Config{
-		ApplicationName: "exp-test-go",
-		Debug:           true,
-	}
-	lambda.Start(epsagon.WrapLambdaHandler(&config, expHandler))
+	config := epsagon.NewTracerConfig("exp-test-go", "")
+	lambda.Start(epsagon.WrapLambdaHandler(config, expHandler))
 	log.Println("exit main")
 }

--- a/example/simple_error/README.md
+++ b/example/simple_error/README.md
@@ -1,0 +1,1 @@
+GOOS=linux go build main.go

--- a/example/simple_error/main.go
+++ b/example/simple_error/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/epsagon/epsagon-go/epsagon"
+	"log"
+)
+
+// Response is an API gateway response type
+type Response events.APIGatewayProxyResponse
+
+func myHandler(request events.APIGatewayProxyRequest) (Response, error) {
+	log.Println("In myHandler, received body: ", request.Body)
+	return Response{StatusCode: 404, Body: "error"}, fmt.Errorf("example error")
+}
+
+func main() {
+	log.Println("enter main")
+	config := epsagon.NewTracerConfig("simple-error-go", "")
+	lambda.Start(epsagon.WrapLambdaHandler(config, myHandler))
+}

--- a/example/simple_error/makefile
+++ b/example/simple_error/makefile
@@ -1,0 +1,11 @@
+
+
+deploy: build
+	sls deploy
+
+build: main
+
+main: main.go
+	go build -o main main.go
+
+.PHONY: all build main

--- a/example/simple_error/serverless.yml
+++ b/example/simple_error/serverless.yml
@@ -1,0 +1,18 @@
+service: example-go-simple-error
+
+provider:
+  name: aws
+  runtime: go1.x
+  region: eu-west-1
+  environment:
+    EPSAGON_TOKEN: ${env:EPSAGON_TOKEN}
+    EPSAGON_COLLECTOR_URL: ${env:EPSAGON_COLLECTOR_URL}
+    EPSAGON_DEBUG: "TRUE"
+
+functions:
+  simple_error:
+    handler: main
+    events:
+    - http:
+        path: hello
+        method: post


### PR DESCRIPTION
Handle the case of a lambda that returns an error to represent that error in the sent trace.

fixes #25 