### PR TITLE
Add metadata only to http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ import (
 	resp, err := client.Get(anyurl)
 ```
 
+If you want to disable data collection only for the calls made by this client set  `client.MetadataOnly = true`
+
 ### aws-sdk-go
 
 Wrapping of aws-sdk-go is done through the Session object that has to be created to communicate with AWS:


### PR DESCRIPTION
Allow users to set `client.MetadataOnly = true` on a specific Epsagon http client wrapper to make it collect only metadata.