### PR TITLE
added TracingTransport for http.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ Epsagon provides out-of-the-box instrumentation (tracing) for many popular frame
 
 ### net/http
 
-Wrapping http requests using the net/http library can be done by wrapping the client:
+Any http request can be traced using a custom RoundTripper implementation and using that in an http.Client:
 
 ```go
 import (
 	"github.com/epsagon/epsagon-go/wrappers/net/http"
 ...
-	client := epsagonhttp.Wrap(http.Client{})
+	client := http.Client{Transport: epsagonhttp.TracingTransport}
 	resp, err := client.Get(anyurl)
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ import (
 	resp, err := client.Get(anyurl)
 ```
 
+The wrapped http.Client functionality exists for backwards compatibility:
+
+```go
+import (
+	"github.com/epsagon/epsagon-go/wrappers/net/http"
+...
+	client := epsagonhttp.Wrap(http.Client{})
+	resp, err := client.Get(anyurl)
+```
+
 If you want to disable data collection only for the calls made by this client set  `client.MetadataOnly = true`
 
 ### aws-sdk-go

--- a/epsagon/concurrent_generic_wrapper_test.go
+++ b/epsagon/concurrent_generic_wrapper_test.go
@@ -4,11 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/epsagon/epsagon-go/epsagon"
-	"github.com/epsagon/epsagon-go/protocol"
-	"github.com/epsagon/epsagon-go/wrappers/net/http"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -18,6 +13,12 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/epsagon/epsagon-go/epsagon"
+	"github.com/epsagon/epsagon-go/protocol"
+	epsagonhttp "github.com/epsagon/epsagon-go/wrappers/net/http"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestEpsagonConcurrentWrapper(t *testing.T) {
@@ -87,7 +88,7 @@ func waitForTraces(start int, end int, traceChannel chan *protocol.Trace, resour
 type HandlerFunc func(res http.ResponseWriter, req *http.Request)
 
 func handleResponse(ctx context.Context, res http.ResponseWriter, req *http.Request) {
-	client := epsagonhttp.Wrap(http.Client{}, ctx)
+	client := http.Client{Transport: epsagonhttp.NewTracingTransport(ctx)}
 	client.Get(fmt.Sprintf("https://www.google.com%s", req.RequestURI))
 	res.Write([]byte(req.RequestURI))
 }

--- a/example/api_gateway/main.go
+++ b/example/api_gateway/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/epsagon/epsagon-go/epsagon"
-	"github.com/epsagon/epsagon-go/wrappers/net/http"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/epsagon/epsagon-go/epsagon"
+	epsagonhttp "github.com/epsagon/epsagon-go/wrappers/net/http"
 )
 
 // Response is an API gateway response type
@@ -15,7 +16,7 @@ type Response events.APIGatewayProxyResponse
 
 func myHandler(request events.APIGatewayProxyRequest) (Response, error) {
 	log.Println("In myHandler, received body: ", request.Body)
-	client := epsagonhttp.Wrap(http.Client{})
+	client := http.Client{Transport: epsagonhttp.NewTracingTransport()}
 	resp, err := client.Get("https://api.randomuser.me")
 	var body string
 	if err == nil {

--- a/example/concurrent_generic_go_functions/main.go
+++ b/example/concurrent_generic_go_functions/main.go
@@ -3,18 +3,19 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/epsagon/epsagon-go/epsagon"
-	"github.com/epsagon/epsagon-go/wrappers/net/http"
 	"log"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/epsagon/epsagon-go/epsagon"
+	epsagonhttp "github.com/epsagon/epsagon-go/wrappers/net/http"
 )
 
 func doTask(ctx context.Context, a int, b string, wg *sync.WaitGroup) (int, error) {
 	defer wg.Done()
 	log.Printf("inside doTask: b = %s", b)
-	client := epsagonhttp.Wrap(http.Client{}, ctx)
+	client := http.Client{Transport: epsagonhttp.NewTracingTransport(ctx)}
 	client.Get("https://epsagon.com/")
 	return a + 1, fmt.Errorf("boom")
 }

--- a/wrappers/net/http/client_test.go
+++ b/wrappers/net/http/client_test.go
@@ -42,7 +42,7 @@ func verifyResponseSuccess(response *http.Response, err error) {
 	Expect(responseString).To(Equal(TEST_RESPONSE_STRING))
 }
 
-var _ = Describe("TracingTransport", func() {
+var _ = Describe("ClientWrapper", func() {
 	var (
 		events        []*protocol.Event
 		exceptions    []*protocol.Exception
@@ -79,7 +79,7 @@ var _ = Describe("TracingTransport", func() {
 		})
 		Context("sending a request to existing server", func() {
 			It("adds an event with no error", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
+				client := Wrap(http.Client{})
 				req, err := http.NewRequest(http.MethodGet, testServer.URL, nil)
 				if err != nil {
 					Fail("couldn't create request")
@@ -88,6 +88,358 @@ var _ = Describe("TracingTransport", func() {
 				Expect(requests).To(HaveLen(1))
 				Expect(events).To(HaveLen(1))
 				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("sending a request to existing server, no tracer", func() {
+			It("adds an event with no error", func() {
+				tracer.GlobalTracer = nil
+				client := Wrap(http.Client{})
+				req, err := http.NewRequest(http.MethodGet, testServer.URL, nil)
+				if err != nil {
+					Fail("couldn't create request")
+				}
+				response, err := client.Do(req)
+				verifyResponseSuccess(response, err)
+			})
+		})
+		Context("request to whitelisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				req, err := http.NewRequest(
+					http.MethodGet,
+					fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN),
+					nil,
+				)
+				if err != nil {
+					Fail("couldn't create request")
+				}
+				client.Do(req)
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("request to blacklisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				req, err := http.NewRequest(
+					http.MethodGet,
+					fmt.Sprintf("https://%s", EPSAGON_DOMAIN),
+					nil,
+				)
+				if err != nil {
+					Fail("couldn't create request")
+				}
+				client.Do(req)
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+	})
+	Describe(".Get", func() {
+		BeforeEach(func() {
+			events = make([]*protocol.Event, 0)
+			exceptions = make([]*protocol.Exception, 0)
+		})
+		Context("request created succesfully", func() {
+			It("Adds event", func() {
+				client := Wrap(http.Client{})
+				client.Get(testServer.URL)
+				Expect(requests).To(HaveLen(1))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				Expect(events[0].Resource.Metadata["response_body"]).To(
+					Equal(string(response_data)))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("sending a request to existing server, no tracer", func() {
+			It("adds an event with no error", func() {
+				tracer.GlobalTracer = nil
+				client := Wrap(http.Client{})
+				response, err := client.Get(testServer.URL)
+				verifyResponseSuccess(response, err)
+			})
+		})
+		Context("request to whitelisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				client.Get(fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("request to blacklisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				client.Get(fmt.Sprintf("https://%s", EPSAGON_DOMAIN))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+		Context("bad input failing to create request", func() {
+			It("Adds event with error code error", func() {
+				client := Wrap(http.Client{})
+				client.Get(testServer.URL + "balbla")
+				Expect(requests).To(HaveLen(0))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+	})
+	Describe(".Post", func() {
+		BeforeEach(func() {
+			events = make([]*protocol.Event, 0)
+			exceptions = make([]*protocol.Exception, 0)
+		})
+		Context("request created succesfully", func() {
+			It("Adds event", func() {
+				client := Wrap(http.Client{})
+				data := "{\"hello\":\"world\"}"
+				client.Post(
+					testServer.URL,
+					"application/json",
+					strings.NewReader(data))
+				Expect(requests).To(HaveLen(1))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				Expect(events[0].Resource.Metadata["response_body"]).To(
+					Equal(string(response_data)))
+				Expect(events[0].Resource.Metadata["request_body"]).To(
+					Equal(data))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("sending a request to existing server, no tracer", func() {
+			It("adds an event with no error", func() {
+				tracer.GlobalTracer = nil
+				client := Wrap(http.Client{})
+				data := "{\"hello\":\"world\"}"
+				response, err := client.Post(
+					testServer.URL,
+					"application/json",
+					strings.NewReader(data))
+				verifyResponseSuccess(response, err)
+			})
+		})
+		Context("client with metadataOnly", func() {
+			It("Adds event", func() {
+				client := Wrap(http.Client{})
+				client.MetadataOnly = true
+				data := "{\"hello\":\"world\"}"
+				client.Post(
+					testServer.URL,
+					"application/json",
+					strings.NewReader(data))
+				Expect(requests).To(HaveLen(1))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				Expect(events[0].Resource.Metadata).NotTo(
+					HaveKey("response_body"))
+				Expect(events[0].Resource.Metadata).NotTo(
+					HaveKey("request_body"))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("request to whitelisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				data := "{\"hello\":\"world\"}"
+				client.Post(
+					fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN),
+					"application/json",
+					strings.NewReader(data))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("request to blacklisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				data := "{\"hello\":\"world\"}"
+				client.Post(
+					fmt.Sprintf("https://%s", EPSAGON_DOMAIN),
+					"application/json",
+					strings.NewReader(data))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+		Context("bad input failing to create request", func() {
+			It("Adds event", func() {
+				client := Wrap(http.Client{})
+				client.Post(
+					testServer.URL+"blabla",
+					"application/json",
+					strings.NewReader("{\"hello\":\"world\"}"))
+				Expect(requests).To(HaveLen(0))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+	})
+	Describe(".PostForm", func() {
+		BeforeEach(func() {
+			events = make([]*protocol.Event, 0)
+			exceptions = make([]*protocol.Exception, 0)
+		})
+		Context("request created succesfully", func() {
+			It("Adds event", func() {
+				client := Wrap(http.Client{})
+				client.PostForm(
+					testServer.URL,
+					map[string][]string{
+						"hello": []string{"world", "of", "serverless"},
+					},
+				)
+				Expect(requests).To(HaveLen(1))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("sending a request to existing server, no tracer", func() {
+			It("adds an event with no error", func() {
+				tracer.GlobalTracer = nil
+				client := Wrap(http.Client{})
+				response, err := client.PostForm(
+					testServer.URL,
+					map[string][]string{
+						"hello": []string{"world", "of", "serverless"},
+					},
+				)
+				verifyResponseSuccess(response, err)
+			})
+		})
+		Context("request to whitelisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				client.PostForm(
+					fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN),
+					map[string][]string{
+						"hello": []string{"world", "of", "serverless"},
+					},
+				)
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("request to blacklisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				client.PostForm(
+					fmt.Sprintf("https://%s", EPSAGON_DOMAIN),
+					map[string][]string{
+						"hello": []string{"world", "of", "serverless"},
+					},
+				)
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+		Context("bad input failing to create request", func() {
+			It("Adds event with error code error", func() {
+				client := Wrap(http.Client{})
+				client.PostForm(
+					testServer.URL+"blabla",
+					map[string][]string{
+						"hello": []string{"world", "of", "serverless"},
+					},
+				)
+				Expect(requests).To(HaveLen(0))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+	})
+	Describe(".Head", func() {
+		BeforeEach(func() {
+			events = make([]*protocol.Event, 0)
+			exceptions = make([]*protocol.Exception, 0)
+		})
+		Context("request created succesfully", func() {
+			It("Adds event", func() {
+				client := Wrap(http.Client{})
+				client.Head(testServer.URL)
+				Expect(requests).To(HaveLen(1))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("sending a request to existing server, no tracer", func() {
+			It("adds an event with no error", func() {
+				tracer.GlobalTracer = nil
+				client := Wrap(http.Client{})
+				_, err := client.Head(testServer.URL)
+				Expect(err).To(BeNil())
+			})
+		})
+		Context("request to whitelisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				client.Head(fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDExists(events[0])
+			})
+		})
+		Context("request to blacklisted url", func() {
+			It("Adds event with trace ID", func() {
+				client := Wrap(http.Client{})
+				client.Head(fmt.Sprintf("https://%s", EPSAGON_DOMAIN))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+		Context("bad input failing to create request", func() {
+			It("Adds event with error code error", func() {
+				client := Wrap(http.Client{})
+				client.Head(testServer.URL + "blabla")
+				Expect(requests).To(HaveLen(0))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
+				verifyTraceIDNotExists(events[0])
+			})
+		})
+	})
+	Describe("http.RoundTripper", func() {
+		BeforeEach(func() {
+			events = make([]*protocol.Event, 0)
+			exceptions = make([]*protocol.Exception, 0)
+			requests = make([]*http.Request, 0)
+		})
+		Context("sending a request to existing server", func() {
+			It("adds an event with no error, truncating the request body", func() {
+				client := &http.Client{Transport: NewTracingTransport()}
+				data := make([]byte, 128*1024)
+				for i := range data {
+					data[i] = byte(1)
+				}
+				req, err := http.NewRequest(
+					http.MethodPost,
+					testServer.URL,
+					bytes.NewReader(data))
+				if err != nil {
+					Fail("couldn't create request")
+				}
+				client.Do(req)
+				Expect(requests).To(HaveLen(1))
+				Expect(events).To(HaveLen(1))
+				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
+				Expect([]byte(events[0].Resource.Metadata["request_body"])).To(HaveCap(MAX_METADATA_SIZE))
 				verifyTraceIDExists(events[0])
 			})
 		})
@@ -121,7 +473,7 @@ var _ = Describe("TracingTransport", func() {
 			})
 		})
 		Context("request to blacklisted url", func() {
-			It("Adds event with trace ID with the response truncated", func() {
+			It("Adds event with trace ID and the response truncated", func() {
 				client := &http.Client{Transport: NewTracingTransport()}
 				req, err := http.NewRequest(
 					http.MethodGet,
@@ -134,239 +486,6 @@ var _ = Describe("TracingTransport", func() {
 				client.Do(req)
 				Expect(events).To(HaveLen(1))
 				Expect([]byte(events[0].Resource.Metadata["response_body"])).To(HaveCap(64 * 1024))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				verifyTraceIDNotExists(events[0])
-			})
-		})
-	})
-	Describe(".Get", func() {
-		BeforeEach(func() {
-			events = make([]*protocol.Event, 0)
-			exceptions = make([]*protocol.Exception, 0)
-		})
-		Context("request created succesfully", func() {
-			It("Adds event", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.Get(testServer.URL)
-				Expect(requests).To(HaveLen(1))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				Expect(events[0].Resource.Metadata["response_body"]).To(
-					Equal(string(response_data)))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("sending a request to existing server, no tracer", func() {
-			It("adds an event with no error", func() {
-				tracer.GlobalTracer = nil
-				client := &http.Client{Transport: NewTracingTransport()}
-				response, err := client.Get(testServer.URL)
-				verifyResponseSuccess(response, err)
-			})
-		})
-		Context("request to whitelisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.Get(fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("request to blacklisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.Get(fmt.Sprintf("https://%s", EPSAGON_DOMAIN))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				verifyTraceIDNotExists(events[0])
-			})
-		})
-	})
-	Describe(".Post", func() {
-		BeforeEach(func() {
-			events = make([]*protocol.Event, 0)
-			exceptions = make([]*protocol.Exception, 0)
-		})
-		Context("request created succesfully", func() {
-			It("Adds event, truncating the request body to 64kb", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				data := make([]byte, 128*1024)
-				for i := range data {
-					data[i] = byte(1)
-				}
-				client.Post(
-					testServer.URL,
-					"application/json",
-					bytes.NewReader(data))
-				Expect(requests).To(HaveLen(1))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				Expect(events[0].Resource.Metadata["response_body"]).To(
-					Equal(string(response_data)))
-				Expect([]byte(events[0].Resource.Metadata["request_body"])).To(
-					HaveCap(64 * 1024))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("sending a request to existing server, no tracer", func() {
-			It("adds an event with no error", func() {
-				tracer.GlobalTracer = nil
-				client := &http.Client{Transport: NewTracingTransport()}
-				data := "{\"hello\":\"world\"}"
-				response, err := client.Post(
-					testServer.URL,
-					"application/json",
-					strings.NewReader(data))
-				verifyResponseSuccess(response, err)
-			})
-		})
-		Context("client with metadataOnly", func() {
-			It("Adds event", func() {
-				transport := NewTracingTransport()
-				transport.MetadataOnly = true
-				client := &http.Client{Transport: transport}
-				data := "{\"hello\":\"world\"}"
-				client.Post(
-					testServer.URL,
-					"application/json",
-					strings.NewReader(data))
-				Expect(requests).To(HaveLen(1))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				Expect(events[0].Resource.Metadata).NotTo(
-					HaveKey("response_body"))
-				Expect(events[0].Resource.Metadata).NotTo(
-					HaveKey("request_body"))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("request to whitelisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				data := "{\"hello\":\"world\"}"
-				client.Post(
-					fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN),
-					"application/json",
-					strings.NewReader(data))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("request to blacklisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				data := "{\"hello\":\"world\"}"
-				client.Post(
-					fmt.Sprintf("https://%s", EPSAGON_DOMAIN),
-					"application/json",
-					strings.NewReader(data))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				verifyTraceIDNotExists(events[0])
-			})
-		})
-	})
-	Describe(".PostForm", func() {
-		BeforeEach(func() {
-			events = make([]*protocol.Event, 0)
-			exceptions = make([]*protocol.Exception, 0)
-		})
-		Context("request created succesfully", func() {
-			It("Adds event", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.PostForm(
-					testServer.URL,
-					map[string][]string{
-						"hello": []string{"world", "of", "serverless"},
-					},
-				)
-				Expect(requests).To(HaveLen(1))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("sending a request to existing server, no tracer", func() {
-			It("adds an event with no error", func() {
-				tracer.GlobalTracer = nil
-				client := &http.Client{Transport: NewTracingTransport()}
-				response, err := client.PostForm(
-					testServer.URL,
-					map[string][]string{
-						"hello": []string{"world", "of", "serverless"},
-					},
-				)
-				verifyResponseSuccess(response, err)
-			})
-		})
-		Context("request to whitelisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.PostForm(
-					fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN),
-					map[string][]string{
-						"hello": []string{"world", "of", "serverless"},
-					},
-				)
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("request to blacklisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.PostForm(
-					fmt.Sprintf("https://%s", EPSAGON_DOMAIN),
-					map[string][]string{
-						"hello": []string{"world", "of", "serverless"},
-					},
-				)
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				verifyTraceIDNotExists(events[0])
-			})
-		})
-	})
-	Describe(".Head", func() {
-		BeforeEach(func() {
-			events = make([]*protocol.Event, 0)
-			exceptions = make([]*protocol.Exception, 0)
-		})
-		Context("request created succesfully", func() {
-			It("Adds event", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.Head(testServer.URL)
-				Expect(requests).To(HaveLen(1))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("sending a request to existing server, no tracer", func() {
-			It("adds an event with no error", func() {
-				tracer.GlobalTracer = nil
-				client := &http.Client{Transport: NewTracingTransport()}
-				_, err := client.Head(testServer.URL)
-				Expect(err).To(BeNil())
-			})
-		})
-		Context("request to whitelisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.Head(fmt.Sprintf("https://test.%s.com", APPSYNC_API_SUBDOMAIN))
-				Expect(events).To(HaveLen(1))
-				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_ERROR))
-				verifyTraceIDExists(events[0])
-			})
-		})
-		Context("request to blacklisted url", func() {
-			It("Adds event with trace ID", func() {
-				client := &http.Client{Transport: NewTracingTransport()}
-				client.Head(fmt.Sprintf("https://%s", EPSAGON_DOMAIN))
-				Expect(events).To(HaveLen(1))
 				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
 				verifyTraceIDNotExists(events[0])
 			})


### PR DESCRIPTION
* Added TracingTransport, an http.RoundTripper implementation for tracing HTTP requests
* Capped metadata for the request & response bodies to 64KB each
* Updated README & examples
* gofmt organized the imports for the files edited