### PR TITLE
Wrappable TracingTransport; lazy tracer setting in RoundTrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,18 @@ Any http request can be traced using a custom RoundTripper implementation and us
 import (
 	"github.com/epsagon/epsagon-go/wrappers/net/http"
 ...
-	client := http.Client{Transport: epsagonhttp.TracingTransport}
+	client := http.Client{Transport: epsagonhttp.NewTracingTransport()}
+	resp, err := client.Get(anyurl)
+```
+
+If you are already using a custom RoundTripper implementation, such as for AWS V4 request signing, you can wrap it:
+
+```go
+import (
+	"github.com/epsagon/epsagon-go/wrappers/net/http"
+...
+	rt := &custom.Roundtripper{}
+	client := http.Client{Transport: epsagonhttp.NewWrappedTracingTransport(rt)}
 	resp, err := client.Get(anyurl)
 ```
 

--- a/wrappers/net/http/client.go
+++ b/wrappers/net/http/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -97,6 +98,9 @@ func (t *TracingTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 	// if the TracingTransport is created before the global tracer is created it will be nil
 	if t.tracer == nil {
 		t.tracer = internal.ExtractTracer(nil)
+		if t.tracer != nil && t.tracer.GetConfig().Debug {
+			log.Println("EPSAGON DEBUG: defaulting to global tracer in RoundTrip")
+		}
 	}
 
 	called := false


### PR DESCRIPTION
Just wrapping the DefaultTransport in the RoundTripper implementation is not very flexible if the http.Client required has it's own custom transport. A good example of this is in calling the AWS Elasticsearch service with signed requests which uses a RoundTripper to sign the request. Kicking myself for not doing this in my initial PR.

Also added a check on the tracer being nil in the RoundTrip method, and setting it to the global tracer if it is. We initialize our dependencies in main and inject them into the handler before calling WrapLambdaHandler, and in doing so the tracer is nil in the TracingTransport as the global tracer has not yet been created. I'm not sure if this solution is the best approach for that and am open to other approaches. Here is an example of the approach we use in our main() functions: 

```
func main() {
	logger := logger.NewLogrus(logger.LogrusConfigEnv("payment-helpers", AppVersion, logrus.New()))

	key := os.Getenv("STRIPE_SECRET_KEY")
	h := handler{stripe: stripe.NewClient(key)}
	a := apigw.NewAPIGWHandler(h, logger)

	lambda.Start(
		epsagon.WrapLambdaHandler(
			instrumentation.EpsagonConfig("payment-helpers"),
			a.Handle))
}
``` 

The http.Client with TracingTransport is created in the stripe.NewClient function, which occurs before the global tracer is created.