### PR TITLE
get global tracer each time

### DIFF
--- a/wrappers/net/http/client.go
+++ b/wrappers/net/http/client.go
@@ -113,6 +113,7 @@ func (t *TracingTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 	}()
 	defer epsagon.GeneralEpsagonRecover("net.http.RoundTripper", "RoundTrip", t.tracer)
 	startTime := tracer.GetTimestamp()
+	reqHeaders, reqBody := t.extractRequestData(req, tr)
 	if !isBlacklistedURL(req.URL) {
 		req.Header[EPSAGON_TRACEID_HEADER_KEY] = []string{generateEpsagonTraceID()}
 	}
@@ -121,7 +122,7 @@ func (t *TracingTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 
 	called = true
 	event := postSuperCall(startTime, req.URL.String(), req.Method, resp, err, t.getMetadataOnly(tr))
-	t.addDataToEvent(req, resp, event, tr)
+	t.addDataToEvent(reqHeaders, reqBody, req, event, tr)
 	tr.AddEvent(event)
 	return
 
@@ -131,15 +132,42 @@ func (t *TracingTransport) getMetadataOnly(tr tracer.Tracer) bool {
 	return t.MetadataOnly || tr.GetConfig().MetadataOnly
 }
 
-func (t *TracingTransport) addDataToEvent(req *http.Request, resp *http.Response, event *protocol.Event, tr tracer.Tracer) {
+func (t *TracingTransport) addDataToEvent(reqHeaders, reqBody string, req *http.Request, event *protocol.Event, tr tracer.Tracer) {
 	if req != nil {
 		addTraceIdToEvent(req, event)
 	}
-	if resp != nil {
-		if !t.getMetadataOnly(tr) {
-			updateRequestData(resp.Request, event.Resource.Metadata)
-		}
+	if !t.getMetadataOnly(tr) {
+		event.Resource.Metadata["request_headers"] = reqHeaders
+		event.Resource.Metadata["request_body"] = reqBody
 	}
+}
+
+func (t *TracingTransport) extractRequestData(req *http.Request, tr tracer.Tracer) (headers string, body string) {
+	if t.getMetadataOnly(tr) {
+		return
+	}
+
+	headers, err := formatHeaders(req.Header)
+	if err != nil {
+		headers = ""
+	}
+
+	if req.Body == nil {
+		return
+	}
+
+	buf, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return
+	}
+	req.Body = ioutil.NopCloser(bytes.NewReader(buf))
+	// truncates request body to the first 64KB
+	trimmed := buf
+	if len(buf) > MAX_METADATA_SIZE {
+		trimmed = buf[0:MAX_METADATA_SIZE]
+	}
+	body = string(trimmed)
+	return
 }
 
 func isBlacklistedURL(parsedUrl *url.URL) bool {


### PR DESCRIPTION
I discovered an issue with assigning the tracer to the TracingTransport instance the first time when RoundTrip is called by the http.Client. If the TracingTransport instance is re-used across multiple Lambda invocations the first invocation will succeed however subsequent requests will fail as the tracer is only valid for a single invocation with a new tracer created on each invocation as at the end of the invocation the tracer is stopped.

This change alters that behavior to use a local variable for the tracer in the TracingTransport instance allowing it to be used across multiple invocations.

----

Discovered an odd issue when wrapping another transport, where after the request is sent the function req.GetBody() is nil. I'm not sure why this is happening when calling the AWS Elasticsearch service with a signed request but I can reproduce it. Made another change to the TracingTransport to capture the request headers & body before sending. This change is implemented similar to how the response body is read & a new reader is created for it.