### PR TITLE
do not truncate response to caller

### DIFF
--- a/wrappers/net/http/client.go
+++ b/wrappers/net/http/client.go
@@ -435,9 +435,10 @@ func updateResponseData(resp *http.Response, resource *protocol.Resource, metada
 	if err == nil {
 		// truncates response body to the first 64KB
 		if len(body) > MAX_METADATA_SIZE {
-			body = body[0:MAX_METADATA_SIZE]
+			resource.Metadata["response_body"] = string(body[0:MAX_METADATA_SIZE])
+		} else {
+			resource.Metadata["response_body"] = string(body)
 		}
-		resource.Metadata["response_body"] = string(body)
 	}
 	resp.Body = newReadCloser(body, err)
 }


### PR DESCRIPTION
This is a fix for a bug I introduced when truncating responses - turns out it returned the truncated response to the caller, resulting in deserialization errors. Whoops.

I tested this in our dev environment and while it fixed the issue with large responses from Elasticsearch, the trace does not show up on the Epsagon side. Not sure why that would be, perhaps an issue with the truncated response? I've attached a debug of the final trace that was sent.
[trace.json.txt](https://github.com/epsagon/epsagon-go/files/5380803/trace.json.txt)
