### PR TITLE
Gin trigger event

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following frameworks are supported by Epsagon:
 |----------------------------------------|---------------------------|
 |[AWS Lambda](#aws-lambda)               |All                        |
 |[Generic Function](#generic)            |All                        |
+|[Gin](#gin)                             |All                        |
 
 
 ### AWS Lambda
@@ -169,6 +170,42 @@ your wrapped function will be displayed with your configured name in all the rel
 traces search, service map and more.
 ```
 		go epsagon.ConcurrentGoWrapper(config, doTask, "<MyInstrumentedFuncName>")(i, "hello", &wg)
+```
+
+### gin
+
+You can easily instrument gin applications with Epsagon:
+
+```go
+import (
+	"github.com/epsagon/epsagon-go/epsagon"
+	epsagongin "github.com/epsagon/epsagon-go/wrappers/gin"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := epsagongin.GinRouterWrapper{
+		IRouter:  gin.Default(),
+		Hostname: "my_site",
+        Config:   epsagon.NewTracerConfig(
+        "test-gin-application", "",
+        ),
+	}
+
+	r.GET("/ping", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"message": "pong",
+		})
+	})
+	r.IRouter.(*gin.Engine).Run()
+```
+
+If you want to instument other integrated libraries inside the gin handler you can get the Epsagon context from the gin.Context to do that:
+
+```go
+client := http.Client{
+    Transport: epsagonhttp.NewTracingTransport(epsagongin.EpsagonContext(c))}
+resp, err := client.Get("http://example.com")
 ```
 
 ## Integrations

--- a/epsagon/aws_v2_wrapper.go
+++ b/epsagon/aws_v2_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/epsagon/epsagon-go/epsagon/aws_sdk_v2_factories"
-	"github.com/epsagon/epsagon-go/internal"
 	"github.com/epsagon/epsagon-go/protocol"
 	"github.com/epsagon/epsagon-go/tracer"
 	"log"
@@ -22,7 +21,7 @@ func WrapAwsV2Service(svcClient interface{}, args ...context.Context) interface{
 		aws.NamedHandler{
 			Name: "epsagon-aws-sdk-v2",
 			Fn: func(r *aws.Request) {
-				currentTracer := internal.ExtractTracer(args)
+				currentTracer := ExtractTracer(args)
 				completeEventData(r, currentTracer)
 			},
 		},

--- a/epsagon/common_utils.go
+++ b/epsagon/common_utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/epsagon/epsagon-go/internal"
 	"github.com/epsagon/epsagon-go/tracer"
 )
 
@@ -39,7 +38,7 @@ func NewTracerConfig(applicationName, token string) *Config {
 
 // Label adds a label to the sent trace
 func Label(key string, value interface{}, args ...context.Context) {
-	currentTracer := internal.ExtractTracer(args)
+	currentTracer := ExtractTracer(args)
 	if currentTracer != nil {
 		currentTracer.AddLabel(key, value)
 	}
@@ -47,7 +46,7 @@ func Label(key string, value interface{}, args ...context.Context) {
 
 // Error adds an error to the sent trace
 func Error(value interface{}, args ...context.Context) {
-	currentTracer := internal.ExtractTracer(args)
+	currentTracer := ExtractTracer(args)
 	if currentTracer != nil {
 		currentTracer.AddError(DefaultErrorType, value)
 	}
@@ -55,7 +54,7 @@ func Error(value interface{}, args ...context.Context) {
 
 // Error adds an error to the sent trace with specific error type
 func TypeError(value interface{}, errorType string, args ...context.Context) {
-	currentTracer := internal.ExtractTracer(args)
+	currentTracer := ExtractTracer(args)
 	if currentTracer != nil {
 		currentTracer.AddError(errorType, value)
 	}

--- a/epsagon/common_utils.go
+++ b/epsagon/common_utils.go
@@ -1,14 +1,22 @@
 package epsagon
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
 
 	"github.com/epsagon/epsagon-go/tracer"
 )
 
 // DefaultErrorType Default custom error type
 const DefaultErrorType = "Error"
+
+// MaxMetadataSize Maximum size of event metadata
+const MaxMetadataSize = 10 * 1024
 
 // Config is the configuration for Epsagon's tracer
 type Config struct {
@@ -52,10 +60,70 @@ func Error(value interface{}, args ...context.Context) {
 	}
 }
 
-// Error adds an error to the sent trace with specific error type
+// TypeError adds an error to the sent trace with specific error type
 func TypeError(value interface{}, errorType string, args ...context.Context) {
 	currentTracer := ExtractTracer(args)
 	if currentTracer != nil {
 		currentTracer.AddError(errorType, value)
 	}
+}
+
+// FormatHeaders format HTTP headers to string - using first header value, ignoring the rest
+func FormatHeaders(headers http.Header) (string, error) {
+	headersToFormat := make(map[string]string)
+	for headerKey, headerValues := range headers {
+		if len(headerValues) > 0 {
+			headersToFormat[headerKey] = headerValues[0]
+		}
+	}
+	headersJSON, err := json.Marshal(headersToFormat)
+	if err != nil {
+		return "", err
+	}
+	return string(headersJSON), nil
+}
+
+// ExtractRequestData extracts headers and body from http.Request
+func ExtractRequestData(req *http.Request) (headers string, body string) {
+	headers, err := FormatHeaders(req.Header)
+	if err != nil {
+		headers = ""
+	}
+
+	if req.Body == nil {
+		return
+	}
+
+	buf, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return
+	}
+	req.Body = ioutil.NopCloser(bytes.NewReader(buf))
+	// truncates request body to the first 64KB
+	trimmed := buf
+	if len(buf) > MaxMetadataSize {
+		trimmed = buf[0:MaxMetadataSize]
+	}
+	body = string(trimmed)
+	return
+}
+
+// NewReadCloser returns an io.ReadCloser
+// will mimick read from body depending on given error
+func NewReadCloser(body []byte, err error) io.ReadCloser {
+	if err != nil {
+		return &errorReader{err: err}
+	}
+	return ioutil.NopCloser(bytes.NewReader(body))
+}
+
+type errorReader struct {
+	err error
+}
+
+func (er *errorReader) Read([]byte) (int, error) {
+	return 0, er.err
+}
+func (er *errorReader) Close() error {
+	return er.err
 }

--- a/epsagon/generic_wrapper.go
+++ b/epsagon/generic_wrapper.go
@@ -1,7 +1,6 @@
 package epsagon
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -104,8 +103,7 @@ func (wrapper *GenericWrapper) transformArguments(args ...interface{}) []reflect
 	inputs := make([]reflect.Value, actualLength)
 	argsInputs := inputs
 	if wrapper.injectContext {
-		inputs[0] = reflect.ValueOf(
-			context.WithValue(context.Background(), "tracer", wrapper.tracer))
+		inputs[0] = reflect.ValueOf(ContextWithTracer(wrapper.tracer))
 		argsInputs = argsInputs[1:]
 	}
 	for k, in := range args {

--- a/epsagon/generic_wrapper_test.go
+++ b/epsagon/generic_wrapper_test.go
@@ -1,7 +1,6 @@
 package epsagon
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -9,43 +8,11 @@ import (
 	"github.com/epsagon/epsagon-go/tracer"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
 )
 
 func TestGenericWrapper(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Generic Wrapper")
-}
-
-type matchUserError struct {
-	exception interface{}
-}
-
-func (matcher *matchUserError) Match(actual interface{}) (bool, error) {
-	uErr, ok := actual.(userError)
-	if !ok {
-		return false, fmt.Errorf("excpects userError, got %v", actual)
-	}
-
-	if !reflect.DeepEqual(uErr.exception, matcher.exception) {
-		return false, fmt.Errorf("expected\n\t%v\nexception, got\n\t%v", matcher.exception, uErr.exception)
-	}
-
-	return true, nil
-}
-
-func (matcher *matchUserError) FailureMessage(actual interface{}) string {
-	return fmt.Sprintf("Expected\n\t%#v\nto be userError with exception\n\t%#v", actual, matcher.exception)
-}
-
-func (matcher *matchUserError) NegatedFailureMessage(actual interface{}) string {
-	return fmt.Sprintf("NegatedFailureMessage")
-}
-
-func MatchUserError(exception interface{}) types.GomegaMatcher {
-	return &matchUserError{
-		exception: exception,
-	}
 }
 
 var _ = Describe("generic_wrapper", func() {

--- a/epsagon/tracer_helpers.go
+++ b/epsagon/tracer_helpers.go
@@ -1,4 +1,4 @@
-package internal
+package epsagon
 
 import (
 	"context"
@@ -6,7 +6,16 @@ import (
 	"github.com/epsagon/epsagon-go/tracer"
 )
 
-// Extracts the tracer from given contexts (using first context),
+type tracerKey string
+
+const tracerKeyValue tracerKey = "tracer"
+
+// ContextWithTracer creates a context with given tracer
+func ContextWithTracer(t tracer.Tracer) context.Context {
+	return context.WithValue(context.Background(), tracerKeyValue, t)
+}
+
+// ExtractTracer Extracts the tracer from given contexts (using first context),
 // returns Global tracer if no context is given and GlobalTracer is valid (= non nil, not stopped)
 func ExtractTracer(ctx []context.Context) tracer.Tracer {
 	if len(ctx) == 0 {
@@ -15,7 +24,7 @@ func ExtractTracer(ctx []context.Context) tracer.Tracer {
 		}
 		return tracer.GlobalTracer
 	}
-	rawValue := ctx[0].Value("tracer")
+	rawValue := ctx[0].Value(tracerKeyValue)
 	if rawValue == nil {
 		panic("Invalid context, see Epsagon Concurrent Generic GO function example")
 	}

--- a/example/gin_wrapper/main.go
+++ b/example/gin_wrapper/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"time"
 
 	"github.com/epsagon/epsagon-go/epsagon"
@@ -13,22 +14,43 @@ import (
 
 func main() {
 	// r := gin.Default()
+	config := epsagon.NewTracerConfig(
+		"erez-test-gin", "",
+	)
+	config.MetadataOnly = false
 	r := epsagongin.GinRouterWrapper{
 		IRouter:  gin.Default(),
 		Hostname: "my_site",
-		Config: epsagon.NewTracerConfig(
-			"erez-test-gin", "",
-		),
+		Config:   config,
 	}
 
+	r.GET("/ping", func(c *gin.Context) {
+		time.Sleep(time.Second * 1)
+		fmt.Println("hello world")
+		c.JSON(200, gin.H{
+			"message": "pong",
+		})
+	})
 	r.POST("/ping", func(c *gin.Context) {
 		time.Sleep(time.Second * 1)
 		body, err := ioutil.ReadAll(c.Request.Body)
 		if err == nil {
-			fmt.Println(body)
+			fmt.Println("Recieved body: ", string(body))
 		} else {
 			fmt.Println("Error reading body: ", err)
 		}
+
+		client := http.Client{
+			Transport: epsagonhttp.NewTracingTransport(epsagongin.EpsagonContext(c))}
+		resp, err := client.Get("http://example.com")
+
+		if err == nil {
+			respBody, err := ioutil.ReadAll(resp.Body)
+			if err == nil {
+				fmt.Println("First 1000 bytes recieved: ", string(respBody[:1000]))
+			}
+		}
+
 		c.JSON(200, gin.H{
 			"message": "pong",
 		})

--- a/example/gin_wrapper/main.go
+++ b/example/gin_wrapper/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/epsagon/epsagon-go/epsagon"
@@ -20,9 +21,14 @@ func main() {
 		),
 	}
 
-	r.GET("/ping", func(c *gin.Context) {
+	r.POST("/ping", func(c *gin.Context) {
 		time.Sleep(time.Second * 1)
-		fmt.Println("hello world")
+		body, err := ioutil.ReadAll(c.Request.Body)
+		if err == nil {
+			fmt.Println(body)
+		} else {
+			fmt.Println("Error reading body: ", err)
+		}
 		c.JSON(200, gin.H{
 			"message": "pong",
 		})

--- a/example/gin_wrapper/main.go
+++ b/example/gin_wrapper/main.go
@@ -5,7 +5,8 @@ import (
 	"time"
 
 	"github.com/epsagon/epsagon-go/epsagon"
-	"github.com/epsagon/epsagon-go/wrappers/gin"
+	epsagongin "github.com/epsagon/epsagon-go/wrappers/gin"
+	epsagonhttp "github.com/epsagon/epsagon-go/wrappers/net/http"
 	"github.com/gin-gonic/gin"
 )
 

--- a/tracer/mocked_tracer.go
+++ b/tracer/mocked_tracer.go
@@ -89,3 +89,13 @@ func (t *MockedEpsagonTracer) AddError(errorType string, value interface{}) {
 		Message: "test",
 	}
 }
+
+// GetRunnerEvent implements AddError
+func (t *MockedEpsagonTracer) GetRunnerEvent() *protocol.Event {
+	for _, event := range *t.Events {
+		if event.Origin == "runner" {
+			return event
+		}
+	}
+	return nil
+}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -60,6 +60,7 @@ type Tracer interface {
 	AddExceptionTypeAndMessage(string, string)
 	AddLabel(string, interface{})
 	AddError(string, interface{})
+	GetRunnerEvent() *protocol.Event
 	Start()
 	Running() bool
 	Stop()
@@ -151,8 +152,8 @@ func HandleSendTracesResponse(resp *http.Response, err error) {
 	}
 }
 
-// getRunnerEvent Gets the runner event, nil if not found
-func (tracer *epsagonTracer) getRunnerEvent() *protocol.Event {
+// GetRunnerEvent Gets the runner event, nil if not found
+func (tracer *epsagonTracer) GetRunnerEvent() *protocol.Event {
 	for _, event := range tracer.events {
 		if event.Origin == "runner" {
 			return event
@@ -236,7 +237,7 @@ func (tracer *epsagonTracer) getTraceJSON(trace *protocol.Trace, runnerEvent *pr
 
 func (tracer *epsagonTracer) getTraceReader() (io.Reader, error) {
 	version := "go " + runtime.Version()
-	runnerEvent := tracer.getRunnerEvent()
+	runnerEvent := tracer.GetRunnerEvent()
 	if runnerEvent != nil {
 		tracer.addRunnerLabels(runnerEvent)
 		tracer.addRunnerException(runnerEvent)

--- a/wrappers/aws/aws-sdk-go/aws/aws.go
+++ b/wrappers/aws/aws-sdk-go/aws/aws.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/epsagon/epsagon-go/epsagon"
-	"github.com/epsagon/epsagon-go/internal"
 	"github.com/epsagon/epsagon-go/protocol"
 	"github.com/epsagon/epsagon-go/tracer"
 	"log"
@@ -23,7 +22,7 @@ func WrapSession(s *session.Session, args ...context.Context) *session.Session {
 		request.NamedHandler{
 			Name: "github.com/epsagon/epsagon-go/wrappers/aws/aws-sdk-go/aws/aws.go",
 			Fn: func(r *request.Request) {
-				currentTracer := internal.ExtractTracer(args)
+				currentTracer := epsagon.ExtractTracer(args)
 				completeEventData(r, currentTracer)
 			},
 		})

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -31,6 +31,9 @@ type GinRouterWrapper struct {
 }
 
 func processRawQuery(urlObj *url.URL, wrapperTracer tracer.Tracer) string {
+	if urlObj == nil {
+		return ""
+	}
 	processed, err := json.Marshal(urlObj.Query())
 	if err != nil {
 		wrapperTracer.AddException(&protocol.Exception{
@@ -72,10 +75,10 @@ func addTriggerEvent(wrapperTracer tracer.Tracer, context *gin.Context, resource
 }
 
 func wrapGinHandler(handler gin.HandlerFunc, hostname string, relativePath string, config *epsagon.Config) gin.HandlerFunc {
+	if config == nil {
+		config = &epsagon.Config{}
+	}
 	return func(c *gin.Context) {
-		if config == nil {
-			config = &epsagon.Config{}
-		}
 		wrapperTracer := tracer.CreateTracer(&config.Config)
 		wrapperTracer.Start()
 		defer wrapperTracer.Stop()

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -1,6 +1,7 @@
 package epsagongin
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -11,6 +12,11 @@ import (
 
 // TracerKey is the key of the epsagon tracer in the gin.Context Keys map passed to the handlers
 const TracerKey = "EpsagonTracer"
+
+// EpsagonContext creates a context.Background() with epsagon's associated tracer for nexted instrumentations
+func EpsagonContext(c *gin.Context) context.Context {
+	return epsagon.ContextWithTracer(c.Keys[TracerKey].(tracer.Tracer))
+}
 
 // GinRouterWrapper is an epsagon instumentation wrapper for gin.RouterGroup
 type GinRouterWrapper struct {

--- a/wrappers/gin/gin_test.go
+++ b/wrappers/gin/gin_test.go
@@ -1,6 +1,9 @@
 package epsagongin
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
 	"net/http/httptest"
 	"testing"
 
@@ -29,35 +32,46 @@ func (me *MockEngine) Handle(httpMethod, relativePath string, handlers ...gin.Ha
 
 var _ = Describe("gin_wrapper", func() {
 	Describe("GinRouterWrapper", func() {
+		var (
+			events         []*protocol.Event
+			exceptions     []*protocol.Exception
+			wrapper        *GinRouterWrapper
+			mockedEngine   *MockEngine
+			called         bool
+			testGinContext *gin.Context
+		)
+		BeforeEach(func() {
+			called = false
+			config := &epsagon.Config{Config: tracer.Config{
+				Disable:  true,
+				TestMode: true,
+			}}
+			events = make([]*protocol.Event, 0)
+			exceptions = make([]*protocol.Exception, 0)
+			tracer.GlobalTracer = &tracer.MockedEpsagonTracer{
+				Events:     &events,
+				Exceptions: &exceptions,
+				Labels:     make(map[string]interface{}),
+				Config:     &config.Config,
+			}
+			mockedEngine = &MockEngine{
+				Engine: gin.New(),
+				TestHandler: func(handler gin.HandlerFunc) {
+					handler(testGinContext)
+				},
+			}
+			wrapper = &GinRouterWrapper{
+				IRouter:  mockedEngine,
+				Hostname: "test",
+				Config:   config,
+			}
+			body := []byte("hello")
+			testGinContext, _ = gin.CreateTestContext(httptest.NewRecorder())
+			testGinContext.Request = httptest.NewRequest("POST", "https://www.help.com", ioutil.NopCloser(bytes.NewReader(body)))
+			Expect(testGinContext.Request).NotTo(Equal(nil))
+		})
 		Context("Happy Flows", func() {
-			var (
-				events       []*protocol.Event
-				exceptions   []*protocol.Exception
-				wrapper      *GinRouterWrapper
-				mockedEngine *MockEngine
-				called       bool
-			)
-			BeforeEach(func() {
-				called = false
-				events = make([]*protocol.Event, 0)
-				exceptions = make([]*protocol.Exception, 0)
-				tracer.GlobalTracer = &tracer.MockedEpsagonTracer{
-					Events:     &events,
-					Exceptions: &exceptions,
-					Labels:     make(map[string]interface{}),
-				}
-				mockedEngine = &MockEngine{Engine: gin.New()}
-				wrapper = &GinRouterWrapper{
-					IRouter:  mockedEngine,
-					Hostname: "test",
-					Config: &epsagon.Config{Config: tracer.Config{
-						Disable:  true,
-						TestMode: true,
-					}},
-				}
-			})
 			It("calls the wrapped function", func() {
-				testGinContext, _ := gin.CreateTestContext(httptest.NewRecorder())
 				mockedEngine.TestHandler = func(handler gin.HandlerFunc) {
 					handler(testGinContext)
 					Expect(called).To(Equal(true))
@@ -65,7 +79,6 @@ var _ = Describe("gin_wrapper", func() {
 				wrapper.GET("/test", func(c *gin.Context) { called = true })
 			})
 			It("passes the tracer through gin context", func() {
-				testGinContext, _ := gin.CreateTestContext(httptest.NewRecorder())
 				mockedEngine.TestHandler = func(handler gin.HandlerFunc) {
 					handler(testGinContext)
 					Expect(called).To(Equal(true))
@@ -79,15 +92,66 @@ var _ = Describe("gin_wrapper", func() {
 					tracer.GlobalTracer.(*tracer.MockedEpsagonTracer).Labels["test"],
 				).To(Equal("ok"))
 			})
-			It("Creates a runner event for the handler invocation", func() {
-				testGinContext, _ := gin.CreateTestContext(httptest.NewRecorder())
+			It("Creates a runner and trigger events for handler invocation", func() {
 				mockedEngine.TestHandler = func(handler gin.HandlerFunc) {
 					handler(testGinContext)
 				}
 				wrapper.GET("/test", func(c *gin.Context) {
 					called = true
 				})
-				Expect(len(events)).To(Equal(1))
+				Expect(len(events)).To(Equal(2))
+			})
+			It("Adds correct trigger event", func() {
+				body := []byte("hello world")
+				testGinContext.Request = httptest.NewRequest(
+					"POST",
+					"https://www.help.com/test?hello=world&good=bye",
+					ioutil.NopCloser(bytes.NewReader(body)))
+				wrapper.Hostname = ""
+				wrapper.GET("/test", func(c *gin.Context) {
+					internalHandlerBody, err := ioutil.ReadAll(c.Request.Body)
+					if err != nil {
+						Expect(true).To(Equal(false))
+					}
+					Expect(internalHandlerBody).To(Equal(body))
+					called = true
+				})
+				Expect(len(events)).To(Equal(2))
+				var triggerEvent *protocol.Event
+				for _, event := range events {
+					if event.Origin == "trigger" {
+						triggerEvent = event
+					}
+				}
+				Expect(triggerEvent).NotTo(Equal(nil))
+				Expect(triggerEvent.Resource.Name).To(Equal("www.help.com"))
+				expectedQuery, _ := json.Marshal(map[string][]string{
+					"hello": {"world"}, "good": {"bye"}})
+				Expect(triggerEvent.Resource.Metadata["query_string_parameters"]).To(
+					Equal(string(expectedQuery)))
+				Expect(triggerEvent.Resource.Metadata["path"]).To(
+					Equal("/test"))
+				Expect(triggerEvent.Resource.Metadata["request_body"]).To(
+					Equal(string(body)))
+			})
+		})
+		Context("Error Flows", func() {
+			It("Adds Exception if handler explodes", func() {
+				errorMessage := "boom"
+				Expect(func() {
+					wrapper.GET("/test", func(c *gin.Context) {
+						panic(errorMessage)
+					})
+				}).To(
+					PanicWith(epsagon.MatchUserError(errorMessage)))
+				Expect(len(events)).To(Equal(2))
+				var runnerEvent *protocol.Event
+				for _, event := range events {
+					if event.Origin == "runner" {
+						runnerEvent = event
+					}
+				}
+				Expect(runnerEvent.Exception).NotTo(Equal(nil))
 			})
 		})
 	})

--- a/wrappers/gin/gin_test.go
+++ b/wrappers/gin/gin_test.go
@@ -125,6 +125,8 @@ var _ = Describe("gin_wrapper", func() {
 				}
 				Expect(triggerEvent).NotTo(Equal(nil))
 				Expect(triggerEvent.Resource.Name).To(Equal("www.help.com"))
+				Expect(triggerEvent.Resource.Type).To(Equal("http"))
+				Expect(triggerEvent.Resource.Operation).To(Equal("POST"))
 				expectedQuery, _ := json.Marshal(map[string][]string{
 					"hello": {"world"}, "good": {"bye"}})
 				Expect(triggerEvent.Resource.Metadata["query_string_parameters"]).To(

--- a/wrappers/net/http/client.go
+++ b/wrappers/net/http/client.go
@@ -1,9 +1,7 @@
 package epsagonhttp
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,7 +22,6 @@ const EPSAGON_DOMAIN = "epsagon.com"
 const APPSYNC_API_SUBDOMAIN = ".appsync-api."
 const AMAZON_REQUEST_ID = "x-amzn-requestid"
 const API_GATEWAY_RESOURCE_TYPE = "api_gateway"
-const MAX_METADATA_SIZE = 10 * 1024
 
 type ValidationFunction func(string, string) bool
 
@@ -109,7 +106,10 @@ func (t *TracingTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 	}()
 	defer epsagon.GeneralEpsagonRecover("net.http.RoundTripper", "RoundTrip", t.tracer)
 	startTime := tracer.GetTimestamp()
-	reqHeaders, reqBody := t.extractRequestData(req, tr)
+	reqHeaders, reqBody := "", ""
+	if !t.getMetadataOnly(tr) {
+		reqHeaders, reqBody = epsagon.ExtractRequestData(req)
+	}
 	if !isBlacklistedURL(req.URL) {
 		req.Header[EPSAGON_TRACEID_HEADER_KEY] = []string{generateEpsagonTraceID()}
 	}
@@ -136,34 +136,6 @@ func (t *TracingTransport) addDataToEvent(reqHeaders, reqBody string, req *http.
 		event.Resource.Metadata["request_headers"] = reqHeaders
 		event.Resource.Metadata["request_body"] = reqBody
 	}
-}
-
-func (t *TracingTransport) extractRequestData(req *http.Request, tr tracer.Tracer) (headers string, body string) {
-	if t.getMetadataOnly(tr) {
-		return
-	}
-
-	headers, err := formatHeaders(req.Header)
-	if err != nil {
-		headers = ""
-	}
-
-	if req.Body == nil {
-		return
-	}
-
-	buf, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		return
-	}
-	req.Body = ioutil.NopCloser(bytes.NewReader(buf))
-	// truncates request body to the first 64KB
-	trimmed := buf
-	if len(buf) > MAX_METADATA_SIZE {
-		trimmed = buf[0:MAX_METADATA_SIZE]
-	}
-	body = string(trimmed)
-	return
 }
 
 func isBlacklistedURL(parsedUrl *url.URL) bool {
@@ -422,7 +394,7 @@ func updateResponseData(resp *http.Response, resource *protocol.Resource, metada
 	if metadataOnly {
 		return
 	}
-	headers, err := formatHeaders(resp.Header)
+	headers, err := epsagon.FormatHeaders(resp.Header)
 	if err == nil {
 		resource.Metadata["response_headers"] = headers
 	}
@@ -430,35 +402,17 @@ func updateResponseData(resp *http.Response, resource *protocol.Resource, metada
 	resp.Body.Close()
 	if err == nil {
 		// truncates response body to the first 64KB
-		if len(body) > MAX_METADATA_SIZE {
-			resource.Metadata["response_body"] = string(body[0:MAX_METADATA_SIZE])
+		if len(body) > epsagon.MaxMetadataSize {
+			resource.Metadata["response_body"] = string(body[0:epsagon.MaxMetadataSize])
 		} else {
 			resource.Metadata["response_body"] = string(body)
 		}
 	}
-	resp.Body = newReadCloser(body, err)
-}
-
-type errorReader struct {
-	err error
-}
-
-func (er *errorReader) Read([]byte) (int, error) {
-	return 0, er.err
-}
-func (er *errorReader) Close() error {
-	return er.err
-}
-
-func newReadCloser(body []byte, err error) io.ReadCloser {
-	if err != nil {
-		return &errorReader{err: err}
-	}
-	return ioutil.NopCloser(bytes.NewReader(body))
+	resp.Body = epsagon.NewReadCloser(body, err)
 }
 
 func updateRequestData(req *http.Request, metadata map[string]string) {
-	headers, err := formatHeaders(req.Header)
+	headers, err := epsagon.FormatHeaders(req.Header)
 	if err == nil {
 		metadata["request_headers"] = headers
 	}
@@ -470,25 +424,10 @@ func updateRequestData(req *http.Request, metadata map[string]string) {
 		bodyBytes, err := ioutil.ReadAll(bodyReader)
 		if err == nil {
 			// truncates request body to the first 64KB
-			if len(bodyBytes) > MAX_METADATA_SIZE {
-				bodyBytes = bodyBytes[0:MAX_METADATA_SIZE]
+			if len(bodyBytes) > epsagon.MaxMetadataSize {
+				bodyBytes = bodyBytes[0:epsagon.MaxMetadataSize]
 			}
 			metadata["request_body"] = string(bodyBytes)
 		}
 	}
-}
-
-// format HTTP headers to string - using first header value, ignoring the rest
-func formatHeaders(headers http.Header) (string, error) {
-	headersToFormat := make(map[string]string)
-	for headerKey, headerValues := range headers {
-		if len(headerValues) > 0 {
-			headersToFormat[headerKey] = headerValues[0]
-		}
-	}
-	headersJson, err := json.Marshal(headersToFormat)
-	if err != nil {
-		return "", err
-	}
-	return string(headersJson), nil
 }

--- a/wrappers/net/http/client.go
+++ b/wrappers/net/http/client.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/epsagon/epsagon-go/epsagon"
-	"github.com/epsagon/epsagon-go/internal"
 	"github.com/epsagon/epsagon-go/protocol"
 	"github.com/epsagon/epsagon-go/tracer"
 	"github.com/google/uuid"
@@ -62,7 +61,7 @@ type ClientWrapper struct {
 
 // Wrap wraps an http.Client to Epsagon's ClientWrapper
 func Wrap(c http.Client, args ...context.Context) ClientWrapper {
-	currentTracer := internal.ExtractTracer(args)
+	currentTracer := epsagon.ExtractTracer(args)
 	return ClientWrapper{c, false, currentTracer}
 }
 
@@ -83,7 +82,7 @@ func NewTracingTransport(args ...context.Context) *TracingTransport {
 }
 
 func NewWrappedTracingTransport(rt http.RoundTripper, args ...context.Context) *TracingTransport {
-	currentTracer := internal.ExtractTracer(args)
+	currentTracer := epsagon.ExtractTracer(args)
 	return &TracingTransport{
 		tracer:    currentTracer,
 		transport: rt,
@@ -96,7 +95,7 @@ func (t *TracingTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 	tr := t.tracer
 	// if the TracingTransport is created before the global tracer is created it will be nil
 	if tr == nil {
-		tr = internal.ExtractTracer(nil)
+		tr = epsagon.ExtractTracer(nil)
 		if tr != nil && tr.GetConfig().Debug {
 			log.Println("EPSAGON DEBUG: defaulting to global tracer in RoundTrip")
 		}

--- a/wrappers/net/http/client_test.go
+++ b/wrappers/net/http/client_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/epsagon/epsagon-go/epsagon"
 	"github.com/epsagon/epsagon-go/protocol"
 	"github.com/epsagon/epsagon-go/tracer"
 	. "github.com/onsi/ginkgo"
@@ -448,7 +449,7 @@ var _ = Describe("ClientWrapper", func() {
 				Expect(requests).To(HaveLen(1))
 				Expect(events).To(HaveLen(1))
 				Expect(events[0].ErrorCode).To(Equal(protocol.ErrorCode_OK))
-				Expect([]byte(events[0].Resource.Metadata["request_body"])).To(HaveCap(MAX_METADATA_SIZE))
+				Expect([]byte(events[0].Resource.Metadata["request_body"])).To(HaveCap(epsagon.MaxMetadataSize))
 				verifyTraceIDExists(events[0])
 			})
 		})


### PR DESCRIPTION
Adds trigger event for gin.
Also in this PR:
* Extracting ExtractTracer to a more extractable package and location to be used by other libraries and setting a non collidable key
* Adding README for gin usage
* Improving Gin example
* Adding Test for Gin handler explosion

In future PR:
- [ ] Wrapping http.ResponseWriter to add support for "response_body" and "resposne_headers" for gin and the generic http.Handle / http.ListenAndServe