### PR TITLE
Wrapper for http handlers and recording response body in gin

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,23 @@ func main() {
 		func(w http.ResponseWriter, req *http.Request) {
 			io.WriteString(w, "pong\n")
 		}),
+        "my-handler-name",
 	)
 
 	http.ListenAndServe(":8080", mux)
 }
+```
+
+The third and fourth arguments to `epsagonhttp.WrapHandleFunc` are optional and set the resource name and the hostname. If the resource name is not set then the wrapped funcdtion name is used and the hostname is taken from the request URL if omitted.
+```go
+	mux.HandleFunc("/ping", epsagonhttp.WrapHandleFunc(
+		epsagon.NewTracerConfig("test-http-mux", ""),
+		func(w http.ResponseWriter, req *http.Request) {
+			io.WriteString(w, "pong\n")
+		}),
+        "my-handler-name",
+		"test.hostname.com",
+	)
 ```
 
 To wrap nested libraries you can get the epsagon context from the request context:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following frameworks are supported by Epsagon:
 |----------------------------------------|---------------------------|
 |[AWS Lambda](#aws-lambda)               |All                        |
 |[Generic Function](#generic)            |All                        |
+|[HTTP](#http)                           |All                        |
 |[Gin](#gin)                             |All                        |
 
 
@@ -170,6 +171,35 @@ your wrapped function will be displayed with your configured name in all the rel
 traces search, service map and more.
 ```
 		go epsagon.ConcurrentGoWrapper(config, doTask, "<MyInstrumentedFuncName>")(i, "hello", &wg)
+```
+
+### http
+
+Wrapping http handlers with Epsagon:
+```go
+import (
+	"github.com/epsagon/epsagon-go/epsagon"
+	epsagonhttp "github.com/epsagon/epsagon-go/wrappers/net/http"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", epsagonhttp.WrapHandleFunc(
+		epsagon.NewTracerConfig("test-http-mux", ""),
+		func(w http.ResponseWriter, req *http.Request) {
+			io.WriteString(w, "pong\n")
+		}),
+	)
+
+	http.ListenAndServe(":8080", mux)
+}
+```
+
+To wrap nested libraries you can get the epsagon context from the request context:
+```go
+client := http.Client{
+    Transport: epsagonhttp.NewTracingTransport(req.Context())}
+resp, err := client.Get("http://example.com")
 ```
 
 ### gin

--- a/epsagon/tracer_helpers.go
+++ b/epsagon/tracer_helpers.go
@@ -11,7 +11,10 @@ type tracerKey string
 const tracerKeyValue tracerKey = "tracer"
 
 // ContextWithTracer creates a context with given tracer
-func ContextWithTracer(t tracer.Tracer) context.Context {
+func ContextWithTracer(t tracer.Tracer, ctx ...context.Context) context.Context {
+	if len(ctx) == 1 {
+		return context.WithValue(ctx[0], tracerKeyValue, t)
+	}
 	return context.WithValue(context.Background(), tracerKeyValue, t)
 }
 

--- a/example/http_mux/main.go
+++ b/example/http_mux/main.go
@@ -26,7 +26,7 @@ func main() {
 					fmt.Println("First 1000 bytes recieved: ", string(respBody[:1000]))
 				}
 			}
-			io.WriteString(w, "ping\n")
+			io.WriteString(w, "pong\n")
 		}),
 	)
 

--- a/example/http_mux/main.go
+++ b/example/http_mux/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/epsagon/epsagon-go/epsagon"
+	epsagonhttp "github.com/epsagon/epsagon-go/wrappers/net/http"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", epsagonhttp.WrapHandleFunc(
+		epsagon.NewTracerConfig("test-http-mux", ""),
+		func(w http.ResponseWriter, req *http.Request) {
+
+			client := http.Client{
+				Transport: epsagonhttp.NewTracingTransport(req.Context())}
+			resp, err := client.Get("http://example.com")
+
+			if err == nil {
+				respBody, err := ioutil.ReadAll(resp.Body)
+				if err == nil {
+					fmt.Println("First 1000 bytes recieved: ", string(respBody[:1000]))
+				}
+			}
+			io.WriteString(w, "ping\n")
+		}),
+	)
+
+	http.ListenAndServe(":8080", mux)
+}

--- a/example/http_mux/main.go
+++ b/example/http_mux/main.go
@@ -27,8 +27,10 @@ func main() {
 				}
 			}
 			io.WriteString(w, "pong\n")
-		}),
-	)
+		},
+		"my-test-function",
+		"test.hostname.com",
+	))
 
 	http.ListenAndServe(":8080", mux)
 }

--- a/tracer/mocked_tracer.go
+++ b/tracer/mocked_tracer.go
@@ -16,6 +16,7 @@ type MockedEpsagonTracer struct {
 	PanicAddEvent     bool
 	PanicAddException bool
 	PanicStop         bool
+	stopped           bool
 }
 
 // Start implementes mocked Start
@@ -23,6 +24,7 @@ func (t *MockedEpsagonTracer) Start() {
 	if t.PanicStart {
 		panic("panic in Start()")
 	}
+	t.stopped = false
 }
 
 // Running implementes mocked Running
@@ -35,11 +37,12 @@ func (t *MockedEpsagonTracer) Stop() {
 	if t.PanicStop {
 		panic("panic in Stop()")
 	}
+	t.stopped = true
 }
 
 // Stopped implementes mocked Stopped
 func (t *MockedEpsagonTracer) Stopped() bool {
-	return false
+	return t.stopped
 }
 
 // AddEvent implementes mocked AddEvent

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -54,6 +54,11 @@ func wrapGinHandler(handler gin.HandlerFunc, hostname string, relativePath strin
 		c.Writer = wrappedResponseWriter
 		defer func() {
 			wrappedResponseWriter.htrw.(*epsagonhttp.WrappedResponseWriter).UpdateResource()
+			userError := recover()
+			if userError != nil {
+				triggerEvent.Resource.Metadata["status_code"] = "500"
+				panic(userError)
+			}
 		}()
 
 		defer func() {

--- a/wrappers/gin/gin_test.go
+++ b/wrappers/gin/gin_test.go
@@ -167,7 +167,7 @@ var _ = Describe("gin_wrapper", func() {
 				wrapper.Config = config
 				body := []byte("hello world")
 				testGinContext.Request = httptest.NewRequest(
-					"POST",
+					"GET",
 					"https://www.help.com/test?hello=world&good=bye",
 					ioutil.NopCloser(bytes.NewReader(body)))
 				wrapper.Hostname = ""

--- a/wrappers/net/http/handler_wrapper.go
+++ b/wrappers/net/http/handler_wrapper.go
@@ -1,0 +1,110 @@
+package epsagonhttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"runtime/debug"
+
+	"github.com/epsagon/epsagon-go/epsagon"
+	"github.com/epsagon/epsagon-go/protocol"
+	"github.com/epsagon/epsagon-go/tracer"
+)
+
+// HandlerFunction is a generic http handler function
+type HandlerFunction func(http.ResponseWriter, *http.Request)
+
+func processRawQuery(urlObj *url.URL, wrapperTracer tracer.Tracer) string {
+	if urlObj == nil {
+		return ""
+	}
+	processed, err := json.Marshal(urlObj.Query())
+	if err != nil {
+		wrapperTracer.AddException(&protocol.Exception{
+			Type:      "trigger-creation",
+			Message:   fmt.Sprintf("Failed to serialize query params %s", urlObj.RawQuery),
+			Traceback: string(debug.Stack()),
+			Time:      tracer.GetTimestamp(),
+		})
+		return ""
+	}
+	return string(processed)
+}
+
+// CreateHTTPTriggerEvent creates an HTTP trigger event
+func CreateHTTPTriggerEvent(wrapperTracer tracer.Tracer, request *http.Request, resourceName string) *protocol.Event {
+	name := resourceName
+	if len(name) == 0 {
+		name = request.Host
+	}
+	event := &protocol.Event{
+		Id:        "",
+		Origin:    "trigger",
+		StartTime: tracer.GetTimestamp(),
+		Resource: &protocol.Resource{
+			Name:      name,
+			Type:      "http",
+			Operation: request.Method,
+			Metadata: map[string]string{
+				"query_string_parameters": processRawQuery(
+					request.URL, wrapperTracer),
+				"path": request.URL.Path,
+			},
+		},
+	}
+	if !wrapperTracer.GetConfig().MetadataOnly {
+		headers, body := epsagon.ExtractRequestData(request)
+		event.Resource.Metadata["request_headers"] = headers
+		event.Resource.Metadata["request_body"] = body
+	}
+	return event
+}
+
+// WrapHandleFunc wraps a generic http.HandleFunc handler function with Epsagon
+// Last two optional paramerts are the name of the handler (will be the resource name of the events) and an optional hardcoded hostname
+func WrapHandleFunc(
+	config *epsagon.Config, handler HandlerFunction, names ...string) HandlerFunction {
+	var hostName, handlerName string
+	if config == nil {
+		config = &epsagon.Config{}
+	}
+	if len(names) >= 1 {
+		handlerName = names[0]
+	}
+	if len(names) >= 2 {
+		hostName = names[1]
+	}
+	return func(rw http.ResponseWriter, request *http.Request) {
+		wrapperTracer := tracer.CreateTracer(&config.Config)
+		wrapperTracer.Start()
+		defer wrapperTracer.Stop()
+
+		triggerEvent := CreateHTTPTriggerEvent(
+			wrapperTracer, request, hostName)
+		wrapperTracer.AddEvent(triggerEvent)
+		triggerEvent.Resource.Metadata["status_code"] = "200"
+		defer func() {
+			userError := recover()
+			if userError != nil {
+				triggerEvent.Resource.Metadata["status_code"] = "500"
+				panic(userError)
+			}
+		}()
+
+		newRequest := request.WithContext(
+			epsagon.ContextWithTracer(wrapperTracer, request.Context()))
+		wrappedResponseWriter := WrappedResponseWriter{
+			ResponseWriter: rw,
+			resource:       triggerEvent.Resource,
+		}
+		defer func() {
+			wrappedResponseWriter.UpdateResource()
+		}()
+
+		wrapper := epsagon.WrapGenericFunction(
+			handler, config, wrapperTracer, false, handlerName,
+		)
+		wrapper.Call(&wrappedResponseWriter, newRequest)
+	}
+}

--- a/wrappers/net/http/handler_wrapper_test.go
+++ b/wrappers/net/http/handler_wrapper_test.go
@@ -1,48 +1,39 @@
-package epsagongin
+package epsagonhttp
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/epsagon/epsagon-go/epsagon"
 	"github.com/epsagon/epsagon-go/protocol"
 	"github.com/epsagon/epsagon-go/tracer"
-	"github.com/gin-gonic/gin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-func TestGinWrapper(t *testing.T) {
+func TestHandlerWrapper(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Gin Wrapper")
 }
 
-type MockEngine struct {
-	*gin.Engine
-	TestHandler func(handler gin.HandlerFunc)
-}
-
-func (me *MockEngine) Handle(httpMethod, relativePath string, handlers ...gin.HandlerFunc) gin.IRoutes {
-	me.TestHandler(handlers[0])
-	return nil
-}
-
 var _ = Describe("gin_wrapper", func() {
-	Describe("GinRouterWrapper", func() {
+	Describe("WrapHandleFunc", func() {
 		var (
 			events         []*protocol.Event
 			exceptions     []*protocol.Exception
-			wrapper        *GinRouterWrapper
-			mockedEngine   *MockEngine
+			request        *http.Request
+			responseWriter *httptest.ResponseRecorder
 			called         bool
-			testGinContext *gin.Context
+			config         *epsagon.Config
 		)
 		BeforeEach(func() {
 			called = false
-			config := &epsagon.Config{Config: tracer.Config{
+			config = &epsagon.Config{Config: tracer.Config{
 				Disable:  true,
 				TestMode: true,
 			}}
@@ -54,51 +45,45 @@ var _ = Describe("gin_wrapper", func() {
 				Labels:     make(map[string]interface{}),
 				Config:     &config.Config,
 			}
-			mockedEngine = &MockEngine{
-				Engine: gin.New(),
-				TestHandler: func(handler gin.HandlerFunc) {
-					handler(testGinContext)
-				},
-			}
-			wrapper = &GinRouterWrapper{
-				IRouter:  mockedEngine,
-				Hostname: "test",
-				Config:   config,
-			}
 			body := []byte("hello")
-			testGinContext, _ = gin.CreateTestContext(httptest.NewRecorder())
-			testGinContext.Request = httptest.NewRequest("POST", "https://www.help.com", ioutil.NopCloser(bytes.NewReader(body)))
-			Expect(testGinContext.Request).NotTo(Equal(nil))
+			request = httptest.NewRequest("POST", "https://www.help.com", ioutil.NopCloser(bytes.NewReader(body)))
+			responseWriter = httptest.NewRecorder()
 		})
 		Context("Happy Flows", func() {
 			It("calls the wrapped function", func() {
-				mockedEngine.TestHandler = func(handler gin.HandlerFunc) {
-					handler(testGinContext)
-					Expect(called).To(Equal(true))
-				}
-				wrapper.GET("/test", func(c *gin.Context) { called = true })
+				wrapper := WrapHandleFunc(
+					config,
+					func(rw http.ResponseWriter, req *http.Request) {
+						called = true
+					},
+				)
+				wrapper(responseWriter, request)
+				Expect(called).To(Equal(true))
 			})
-			It("passes the tracer through gin context", func() {
-				mockedEngine.TestHandler = func(handler gin.HandlerFunc) {
-					handler(testGinContext)
-					Expect(called).To(Equal(true))
-				}
-				wrapper.GET("/test", func(c *gin.Context) {
-					tracer := c.Keys[TracerKey].(tracer.Tracer)
-					tracer.AddLabel("test", "ok")
-					called = true
-				})
+			It("passes the tracer through request context", func() {
+				wrapper := WrapHandleFunc(
+					config,
+					func(rw http.ResponseWriter, req *http.Request) {
+						called = true
+						tracer := epsagon.ExtractTracer([]context.Context{req.Context()})
+						tracer.AddLabel("test", "ok")
+					},
+				)
+				wrapper(responseWriter, request)
+				Expect(called).To(Equal(true))
 				Expect(
 					tracer.GlobalTracer.(*tracer.MockedEpsagonTracer).Labels["test"],
 				).To(Equal("ok"))
 			})
 			It("Creates a runner and trigger events for handler invocation", func() {
-				mockedEngine.TestHandler = func(handler gin.HandlerFunc) {
-					handler(testGinContext)
-				}
-				wrapper.GET("/test", func(c *gin.Context) {
-					called = true
-				})
+				wrapper := WrapHandleFunc(
+					config,
+					func(rw http.ResponseWriter, req *http.Request) {
+						called = true
+					},
+					"test-handler",
+				)
+				wrapper(responseWriter, request)
 				Expect(len(events)).To(Equal(2))
 				var runnerEvent *protocol.Event
 				for _, event := range events {
@@ -107,25 +92,38 @@ var _ = Describe("gin_wrapper", func() {
 					}
 				}
 				Expect(runnerEvent).NotTo(Equal(nil))
-				Expect(runnerEvent.Resource.Type).To(Equal("gin"))
-				Expect(runnerEvent.Resource.Name).To(Equal("/test"))
+				Expect(runnerEvent.Resource.Type).To(Equal("go-function"))
+				Expect(runnerEvent.Resource.Name).To(Equal("test-handler"))
 			})
 			It("Adds correct trigger event", func() {
 				body := []byte("hello world")
-				testGinContext.Request = httptest.NewRequest(
+				request = httptest.NewRequest(
 					"POST",
 					"https://www.help.com/test?hello=world&good=bye",
 					ioutil.NopCloser(bytes.NewReader(body)))
-				wrapper.Hostname = ""
-				wrapper.GET("/test", func(c *gin.Context) {
-					internalHandlerBody, err := ioutil.ReadAll(c.Request.Body)
-					if err != nil {
-						Expect(true).To(Equal(false))
-					}
-					Expect(internalHandlerBody).To(Equal(body))
-					called = true
-					c.JSON(200, gin.H{"hello": "world"})
-				})
+				wrapper := WrapHandleFunc(
+					config,
+					func(rw http.ResponseWriter, req *http.Request) {
+						called = true
+						internalHandlerBody, err := ioutil.ReadAll(req.Body)
+						if err != nil {
+							Expect(true).To(Equal(false))
+						}
+						Expect(internalHandlerBody).To(Equal(body))
+						resp, err := json.Marshal(map[string]string{"hello": "world"})
+						if err != nil {
+							Expect(true).To(Equal(false))
+						}
+						rw.Header().Add("Content-Type", "application/json; charset=utf-8")
+						_, err = rw.Write(resp)
+						if err != nil {
+							Expect(true).To(Equal(false))
+						}
+
+					},
+					"test-handler",
+				)
+				wrapper(responseWriter, request)
 				Expect(len(events)).To(Equal(2))
 				var triggerEvent *protocol.Event
 				for _, event := range events {
@@ -157,11 +155,18 @@ var _ = Describe("gin_wrapper", func() {
 			It("Adds Exception if handler explodes", func() {
 				errorMessage := "boom"
 				Expect(func() {
-					wrapper.GET("/test", func(c *gin.Context) {
-						panic(errorMessage)
-					})
+					wrapper := WrapHandleFunc(
+						config,
+						func(rw http.ResponseWriter, req *http.Request) {
+							called = true
+							panic(errorMessage)
+						},
+						"test-handler",
+					)
+					wrapper(responseWriter, request)
 				}).To(
 					PanicWith(epsagon.MatchUserError(errorMessage)))
+				Expect(called).To(Equal(true))
 				Expect(len(events)).To(Equal(2))
 				var runnerEvent, triggerEvent *protocol.Event
 				for _, event := range events {
@@ -172,9 +177,6 @@ var _ = Describe("gin_wrapper", func() {
 						triggerEvent = event
 					}
 				}
-				Expect(
-					tracer.GlobalTracer.(*tracer.MockedEpsagonTracer).Stopped(),
-				).To(Equal(true))
 				Expect(runnerEvent.Exception).NotTo(Equal(nil))
 				Expect(triggerEvent.Exception).NotTo(Equal(nil))
 				Expect(triggerEvent.Resource.Metadata["status_code"]).To(

--- a/wrappers/net/http/response_writer.go
+++ b/wrappers/net/http/response_writer.go
@@ -1,0 +1,144 @@
+package epsagonhttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"runtime/debug"
+
+	"github.com/epsagon/epsagon-go/epsagon"
+	"github.com/epsagon/epsagon-go/protocol"
+	"github.com/epsagon/epsagon-go/tracer"
+)
+
+// HandlerFunction is a generic http handler function
+type HandlerFunction func(http.ResponseWriter, *http.Request)
+
+// WrappedResponseWriter is wrapping Resposne writer with Epsagon
+// to enrich the trace with data from the response
+type WrappedResponseWriter struct {
+	http.ResponseWriter
+	resource *protocol.Resource
+	buf      bytes.Buffer
+}
+
+// CreateWrappedResponseWriter creates a newWrappedResponseWriter
+func CreateWrappedResponseWriter(rw http.ResponseWriter, resource *protocol.Resource) *WrappedResponseWriter {
+	return &WrappedResponseWriter{
+		ResponseWriter: rw,
+		resource:       resource,
+		buf:            bytes.Buffer{},
+	}
+}
+
+// Header wrapper
+func (w *WrappedResponseWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+
+// WriteHeader wrapper, will set status_code immediately
+func (w *WrappedResponseWriter) WriteHeader(statusCode int) {
+	w.resource.Metadata["status_code"] = fmt.Sprint(statusCode)
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Write wrapper
+func (w *WrappedResponseWriter) Write(data []byte) (int, error) {
+	w.buf.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+// UpdateResource updates the connected resource with the response headers and body
+func (w *WrappedResponseWriter) UpdateResource() {
+	w.resource.Metadata["response_headers"], _ = epsagon.FormatHeaders(w.ResponseWriter.Header())
+	w.resource.Metadata["response_body"] = w.buf.String()
+}
+
+func processRawQuery(urlObj *url.URL, wrapperTracer tracer.Tracer) string {
+	if urlObj == nil {
+		return ""
+	}
+	processed, err := json.Marshal(urlObj.Query())
+	if err != nil {
+		wrapperTracer.AddException(&protocol.Exception{
+			Type:      "trigger-creation",
+			Message:   fmt.Sprintf("Failed to serialize query params %s", urlObj.RawQuery),
+			Traceback: string(debug.Stack()),
+			Time:      tracer.GetTimestamp(),
+		})
+		return ""
+	}
+	return string(processed)
+}
+
+// CreateHTTPTriggerEvent creates an HTTP trigger event
+func CreateHTTPTriggerEvent(wrapperTracer tracer.Tracer, request *http.Request, resourceName string) *protocol.Event {
+	name := resourceName
+	if len(name) == 0 {
+		name = request.Host
+	}
+	event := &protocol.Event{
+		Id:        "",
+		Origin:    "trigger",
+		StartTime: tracer.GetTimestamp(),
+		Resource: &protocol.Resource{
+			Name:      name,
+			Type:      "http",
+			Operation: request.Method,
+			Metadata: map[string]string{
+				"query_string_parameters": processRawQuery(
+					request.URL, wrapperTracer),
+				"path": request.URL.Path,
+			},
+		},
+	}
+	if !wrapperTracer.GetConfig().MetadataOnly {
+		headers, body := epsagon.ExtractRequestData(request)
+		event.Resource.Metadata["request_headers"] = headers
+		event.Resource.Metadata["request_body"] = body
+	}
+	return event
+}
+
+// WrapHandleFunc wraps a generic http.HandleFunc handler function with Epsagon
+// Last two optional paramerts are the name of the handler (will be the resource name of the events) and an optional hardcoded hostname
+func WrapHandleFunc(
+	config *epsagon.Config, handler HandlerFunction, names ...string) HandlerFunction {
+	var hostName, handlerName string
+	if config == nil {
+		config = &epsagon.Config{}
+	}
+	if len(names) >= 1 {
+		handlerName = names[0]
+	}
+	if len(names) >= 2 {
+		hostName = names[1]
+	}
+	return func(rw http.ResponseWriter, request *http.Request) {
+		wrapperTracer := tracer.CreateTracer(&config.Config)
+		wrapperTracer.Start()
+		defer wrapperTracer.Stop()
+
+		triggerEvent := CreateHTTPTriggerEvent(
+			wrapperTracer, request, hostName)
+		wrapperTracer.AddEvent(triggerEvent)
+		triggerEvent.Resource.Metadata["status_code"] = "500"
+
+		newRequest := request.WithContext(
+			epsagon.ContextWithTracer(wrapperTracer, request.Context()))
+		wrappedResponseWriter := WrappedResponseWriter{
+			ResponseWriter: rw,
+			resource:       triggerEvent.Resource,
+		}
+		defer func() {
+			wrappedResponseWriter.UpdateResource()
+		}()
+
+		wrapper := epsagon.WrapGenericFunction(
+			handler, config, wrapperTracer, false, handlerName,
+		)
+		wrapper.Call(wrappedResponseWriter, newRequest)
+	}
+}

--- a/wrappers/net/http/response_writer.go
+++ b/wrappers/net/http/response_writer.go
@@ -2,19 +2,12 @@ package epsagonhttp
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"runtime/debug"
 
 	"github.com/epsagon/epsagon-go/epsagon"
 	"github.com/epsagon/epsagon-go/protocol"
-	"github.com/epsagon/epsagon-go/tracer"
 )
-
-// HandlerFunction is a generic http handler function
-type HandlerFunction func(http.ResponseWriter, *http.Request)
 
 // WrappedResponseWriter is wrapping Resposne writer with Epsagon
 // to enrich the trace with data from the response
@@ -54,91 +47,4 @@ func (w *WrappedResponseWriter) Write(data []byte) (int, error) {
 func (w *WrappedResponseWriter) UpdateResource() {
 	w.resource.Metadata["response_headers"], _ = epsagon.FormatHeaders(w.ResponseWriter.Header())
 	w.resource.Metadata["response_body"] = w.buf.String()
-}
-
-func processRawQuery(urlObj *url.URL, wrapperTracer tracer.Tracer) string {
-	if urlObj == nil {
-		return ""
-	}
-	processed, err := json.Marshal(urlObj.Query())
-	if err != nil {
-		wrapperTracer.AddException(&protocol.Exception{
-			Type:      "trigger-creation",
-			Message:   fmt.Sprintf("Failed to serialize query params %s", urlObj.RawQuery),
-			Traceback: string(debug.Stack()),
-			Time:      tracer.GetTimestamp(),
-		})
-		return ""
-	}
-	return string(processed)
-}
-
-// CreateHTTPTriggerEvent creates an HTTP trigger event
-func CreateHTTPTriggerEvent(wrapperTracer tracer.Tracer, request *http.Request, resourceName string) *protocol.Event {
-	name := resourceName
-	if len(name) == 0 {
-		name = request.Host
-	}
-	event := &protocol.Event{
-		Id:        "",
-		Origin:    "trigger",
-		StartTime: tracer.GetTimestamp(),
-		Resource: &protocol.Resource{
-			Name:      name,
-			Type:      "http",
-			Operation: request.Method,
-			Metadata: map[string]string{
-				"query_string_parameters": processRawQuery(
-					request.URL, wrapperTracer),
-				"path": request.URL.Path,
-			},
-		},
-	}
-	if !wrapperTracer.GetConfig().MetadataOnly {
-		headers, body := epsagon.ExtractRequestData(request)
-		event.Resource.Metadata["request_headers"] = headers
-		event.Resource.Metadata["request_body"] = body
-	}
-	return event
-}
-
-// WrapHandleFunc wraps a generic http.HandleFunc handler function with Epsagon
-// Last two optional paramerts are the name of the handler (will be the resource name of the events) and an optional hardcoded hostname
-func WrapHandleFunc(
-	config *epsagon.Config, handler HandlerFunction, names ...string) HandlerFunction {
-	var hostName, handlerName string
-	if config == nil {
-		config = &epsagon.Config{}
-	}
-	if len(names) >= 1 {
-		handlerName = names[0]
-	}
-	if len(names) >= 2 {
-		hostName = names[1]
-	}
-	return func(rw http.ResponseWriter, request *http.Request) {
-		wrapperTracer := tracer.CreateTracer(&config.Config)
-		wrapperTracer.Start()
-		defer wrapperTracer.Stop()
-
-		triggerEvent := CreateHTTPTriggerEvent(
-			wrapperTracer, request, hostName)
-		wrapperTracer.AddEvent(triggerEvent)
-		triggerEvent.Resource.Metadata["status_code"] = "500"
-
-		newRequest := request.WithContext(
-			epsagon.ContextWithTracer(wrapperTracer, request.Context()))
-		wrappedResponseWriter := WrappedResponseWriter{
-			ResponseWriter: rw,
-			resource:       triggerEvent.Resource,
-		}
-		defer func() {
-			wrappedResponseWriter.UpdateResource()
-		}()
-
-		wrapper := epsagon.WrapGenericFunction(
-			handler, config, wrapperTracer, false, handlerName,
-		)
-		wrapper.Call(wrappedResponseWriter, newRequest)
-	}
 }


### PR DESCRIPTION
Adding support for Go's natural http server and collecting resposne_body and response_headers in gin as well.