### PR TITLE
Fix gin resource type

### DIFF
--- a/epsagon/generic_wrapper.go
+++ b/epsagon/generic_wrapper.go
@@ -42,6 +42,11 @@ func WrapGenericFunction(
 	}
 }
 
+// GetRunnerEvent returns the wrapper runner event
+func (wrapper *GenericWrapper) GetRunnerEvent() *protocol.Event {
+	return wrapper.runner
+}
+
 // createRunner creates a runner event but does not add it to the tracer
 // the runner is saved for further manipulations at wrapper.runner
 func (wrapper *GenericWrapper) createRunner() {

--- a/example/gin_wrapper/main.go
+++ b/example/gin_wrapper/main.go
@@ -42,7 +42,7 @@ func main() {
 
 		client := http.Client{
 			Transport: epsagonhttp.NewTracingTransport(epsagongin.EpsagonContext(c))}
-		resp, err := client.Get("http://example.com")
+		resp, err := client.Get("http://www.example.com")
 
 		if err == nil {
 			respBody, err := ioutil.ReadAll(resp.Body)

--- a/tracer/mocked_tracer.go
+++ b/tracer/mocked_tracer.go
@@ -1,6 +1,8 @@
 package tracer
 
 import (
+	"time"
+
 	"github.com/epsagon/epsagon-go/protocol"
 )
 
@@ -16,6 +18,8 @@ type MockedEpsagonTracer struct {
 	PanicAddEvent     bool
 	PanicAddException bool
 	PanicStop         bool
+	DelayAddEvent     bool
+	DelayedEventsChan chan bool
 	stopped           bool
 }
 
@@ -50,7 +54,15 @@ func (t *MockedEpsagonTracer) AddEvent(e *protocol.Event) {
 	if t.PanicAddEvent {
 		panic("panic in AddEvent()")
 	}
-	*t.Events = append(*t.Events, e)
+	if t.DelayAddEvent {
+		go func() {
+			time.Sleep(time.Second)
+			*t.Events = append(*t.Events, e)
+			t.DelayedEventsChan <- true
+		}()
+	} else {
+		*t.Events = append(*t.Events, e)
+	}
 }
 
 // AddException implementes mocked AddEvent

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -40,8 +40,10 @@ func wrapGinWriter(c *gin.Context, triggerEvent *protocol.Event) {
 	c.Writer = wrappedResponseWriter
 }
 
-func postExecutionUpdates(wrapperTracer tracer.Tracer, triggerEvent *protocol.Event, c *gin.Context) {
-	runner := wrapperTracer.GetRunnerEvent()
+func postExecutionUpdates(
+	wrapperTracer tracer.Tracer, triggerEvent *protocol.Event,
+	c *gin.Context, handlerWrapper *epsagon.GenericWrapper) {
+	runner := handlerWrapper.GetRunnerEvent()
 	if runner != nil {
 		runner.Resource.Type = "gin"
 	}
@@ -75,7 +77,7 @@ func wrapGinHandler(handler gin.HandlerFunc, hostname string, relativePath strin
 		if !config.MetadataOnly {
 			wrapGinWriter(c, triggerEvent)
 		}
-		defer postExecutionUpdates(wrapperTracer, triggerEvent, c)
+		defer postExecutionUpdates(wrapperTracer, triggerEvent, c, wrapper)
 		wrapper.Call(c)
 		triggerEvent.Resource.Metadata["status_code"] = fmt.Sprint(c.Writer.Status())
 	}


### PR DESCRIPTION
There is an issue with the gin wrapper not waiting for the event to actually be processed by the tracer - in that case it will not update the event resource type.
Sometimes this happens a lot - depending on the gin server, but usually between the moment the event is added to the moment the wrapper is trying to add the resource type there are no commands that will make the go routine sleep - so it is a toss up between the defer go routine  and the tracer go routine..

This will fix this issue by updating the event itself through the wrapper's pointer, so it will be updated even if the tracer haven't processed it.