### PR TITLE
created shortcut for router.Run

### DIFF
--- a/example/gin_wrapper/main.go
+++ b/example/gin_wrapper/main.go
@@ -13,14 +13,13 @@ import (
 )
 
 func main() {
-	// r := gin.Default()
 	config := epsagon.NewTracerConfig(
-		"erez-test-gin", "",
+		"gin-wrapper-test", "",
 	)
 	config.MetadataOnly = false
 	r := epsagongin.GinRouterWrapper{
 		IRouter:  gin.Default(),
-		Hostname: "my_site",
+		Hostname: "my-site",
 		Config:   config,
 	}
 
@@ -55,6 +54,13 @@ func main() {
 			"message": "pong",
 		})
 	})
-	// r.Run()
-	r.IRouter.(*gin.Engine).Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
+
+	/* listen and serve on 0.0.0.0:<PORT> */
+	/* for windows - localhost:<PORT> */
+	/* Port arg format: ":<PORT>" "*/
+	err := r.Run(":3001")
+
+	if err != nil {
+		fmt.Println(err)
+	}
 }

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -128,8 +128,8 @@ func (router *GinRouterWrapper) HEAD(relativePath string, handlers ...gin.Handle
 }
 
 // Run is a shortcut for router.IRouter.(*gin.Engine).Run()
-func (router *GinRouterWrapper) Run(addr ...string) {
-	router.IRouter.(*gin.Engine).Run(addr)
+func (router *GinRouterWrapper) Run(addr ...string) error {
+	return router.IRouter.(*gin.Engine).Run(addr)
 }
 
 func (grw *wrappedGinWriter) Header() http.Header {

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -2,7 +2,6 @@ package epsagongin
 
 import (
 	"context"
-	"os"
 	"fmt"
 	"net/http"
 

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -129,7 +129,13 @@ func (router *GinRouterWrapper) HEAD(relativePath string, handlers ...gin.Handle
 
 // Run is a shortcut for router.IRouter.(*gin.Engine).Run()
 func (router *GinRouterWrapper) Run(addr ...string) error {
-	return router.IRouter.(*gin.Engine).Run(addr)
+	engine, ok := router.IRouter.(*gin.Engine)
+
+	if ! ok {
+		return fmt.Errorf("Could not start Gin engine")
+	}
+
+	return engine.Run(addr...)
 }
 
 func (grw *wrappedGinWriter) Header() http.Header {

--- a/wrappers/gin/gin.go
+++ b/wrappers/gin/gin.go
@@ -2,6 +2,7 @@ package epsagongin
 
 import (
 	"context"
+	"os"
 	"fmt"
 	"net/http"
 
@@ -127,12 +128,19 @@ func (router *GinRouterWrapper) HEAD(relativePath string, handlers ...gin.Handle
 	return router.Handle(http.MethodHead, relativePath, handlers...)
 }
 
+// Run is a shortcut for router.IRouter.(*gin.Engine).Run()
+func (router *GinRouterWrapper) Run(addr ...string) {
+	router.IRouter.(*gin.Engine).Run(addr)
+}
+
 func (grw *wrappedGinWriter) Header() http.Header {
 	return grw.htrw.Header()
 }
+
 func (grw *wrappedGinWriter) Write(data []byte) (int, error) {
 	return grw.htrw.Write(data)
 }
+
 func (grw *wrappedGinWriter) WriteHeader(statusCode int) {
 	grw.htrw.WriteHeader(statusCode)
 }


### PR DESCRIPTION
Rather than type out router.IRouter.(*gin.Engine).Run() with no support for optional ports, add intuitive support for router.Run(optional ports).