### PR TITLE
Support sending traces before lambda timeout EP-7409

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,15 +465,15 @@ import (
 
 Advanced options can be configured as a parameter to the `Config` struct to the `WrapLambdaHandler` or as environment variables.
 
-|Parameter             |Environment Variable          |Type   |Default      |Description                                                                        |
-|----------------------|------------------------------|-------|-------------|-----------------------------------------------------------------------------------|
-|Token                 |EPSAGON_TOKEN                 |String |-            |Epsagon account token                                                              |
-|ApplicationName       |-                             |String |-            |Application name that will be set for traces                                       |
-|MetadataOnly          |EPSAGON_METADATA              |Boolean|`true`       |Whether to send only the metadata (`True`) or also the payloads (`False`)          |
-|CollectorURL          |EPSAGON_COLLECTOR_URL         |String |-            |The address of the trace collector to send trace to                                |
-|Debug                 |EPSAGON_DEBUG                 |Boolean|`False`      |Enable debug prints for troubleshooting                                            |
-|SendTimeout           |EPSAGON_SEND_TIMEOUT_SEC      |String |`1s`         |The timeout duration to send the traces to the trace collector                     |
-
+|Parameter             |Environment Variable                |Type   |Default      |Description                                                                        |
+|----------------------|------------------------------------|-------|-------------|-----------------------------------------------------------------------------------|
+|Token                 |EPSAGON_TOKEN                       |String |-            |Epsagon account token                                                              |
+|ApplicationName       |-                                   |String |-            |Application name that will be set for traces                                       |
+|MetadataOnly          |EPSAGON_METADATA                    |Boolean|`true`       |Whether to send only the metadata (`True`) or also the payloads (`False`)          |
+|CollectorURL          |EPSAGON_COLLECTOR_URL               |String |-            |The address of the trace collector to send trace to                                |
+|Debug                 |EPSAGON_DEBUG                       |Boolean|`False`      |Enable debug prints for troubleshooting                                            |
+|SendTimeout           |EPSAGON_SEND_TIMEOUT_SEC            |String |`1s`         |The timeout duration to send the traces to the trace collector                     |
+|_                     |EPSAGON_LAMBDA_TIMEOUT_THRESHOLD_MS |Integer|`200`        |The threshold in milliseconds to send the trace before a Lambda timeout occurs     |
 
 
 ## Getting Help

--- a/epsagon/lambda_wrapper.go
+++ b/epsagon/lambda_wrapper.go
@@ -19,6 +19,8 @@ var (
 	coldStart = true
 )
 
+const timeoutErrorCode = 3
+
 type genericLambdaHandler func(context.Context, json.RawMessage) (interface{}, error)
 
 // epsagonLambdaWrapper is a generic lambda function type
@@ -173,7 +175,7 @@ func (wrapper *epsagonLambdaWrapper) trackTimeout(ctx context.Context, preInvoke
 		for range timeoutChannel {
 			if wrapper.invoking {
 				lambdaEvent := createLambdaEvent(preInvokeInfo)
-				lambdaEvent.ErrorCode = 3
+				lambdaEvent.ErrorCode = timeoutErrorCode
 
 				wrapper.tracer.AddEvent(lambdaEvent)
 				wrapper.tracer.Stop()

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -56,10 +56,10 @@ var strongKeys = map[string]bool{
 }
 
 // threshold in milliseconds to send the trace before a Lambda timeout occurs
-const defaultLambdaTimeoutThresholdMs = 200
+const DefaultLambdaTimeoutThresholdMs = 200
 
 func GetLambdaTimeoutThresholdMs() int {
-	timeoutThresholdMs := defaultLambdaTimeoutThresholdMs
+	timeoutThresholdMs := DefaultLambdaTimeoutThresholdMs
 	userDefinedThreshold, ok := os.LookupEnv("EPSAGON_LAMBDA_TIMEOUT_THRESHOLD_MS")
 	if ok {
 		if userDefinedThreshold, err := strconv.Atoi(userDefinedThreshold); err == nil {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -55,6 +55,20 @@ var strongKeys = map[string]bool{
 	"item_hash":              true,
 }
 
+// threshold in milliseconds to send the trace before a Lambda timeout occurs
+const defaultLambdaTimeoutThresholdMs = 200
+
+func GetLambdaTimeoutThresholdMs() int {
+	timeoutThresholdMs := defaultLambdaTimeoutThresholdMs
+	userDefinedThreshold, ok := os.LookupEnv("EPSAGON_LAMBDA_TIMEOUT_THRESHOLD_MS")
+	if ok {
+		if userDefinedThreshold, err := strconv.Atoi(userDefinedThreshold); err == nil {
+			timeoutThresholdMs = userDefinedThreshold
+		}
+	}
+	return timeoutThresholdMs
+}
+
 // Tracer is what a general program tracer has to provide
 type Tracer interface {
 	AddEvent(*protocol.Event)


### PR DESCRIPTION
- Environment variable name and defaults are copied from our other instrumentation libraries.

<img width="1537" alt="Screen Shot 2021-08-18 at 14 28 40" src="https://user-images.githubusercontent.com/37577482/129890587-bca7e472-565e-4d63-b5c7-a73f5bfbc991.png">